### PR TITLE
Add UnitForumRole and SpecialForumRole models and admin pages

### DIFF
--- a/app/admin/special_forum_roles.rb
+++ b/app/admin/special_forum_roles.rb
@@ -1,23 +1,19 @@
-ActiveAdmin.register UnitForumRole do
-  permit_params :unit_id, :access_level, :forum_id, :role_id,
+ActiveAdmin.register SpecialForumRole do
+  permit_params :special_attribute, :forum_id, :role_id,
                 :discourse_role_id, :vanilla_role_id
-
-  includes :unit
 
   scope :all, default: true
   scope :discourse
   scope :vanilla
 
-  filter :unit, collection: -> { Unit.active.order(:ancestry, :order) }
-  filter :access_level, as: :select, collection: UnitForumRole.access_levels
-  filter :forum_id, as: :select, collection: UnitForumRole.forum_ids
+  filter :special_attribute, as: :select, collection: SpecialForumRole.special_attributes
+  filter :forum_id, as: :select, collection: SpecialForumRole.forum_ids
   filter :role_id
 
   index do
     @roles ||= controller.roles
     selectable_column
-    column :unit
-    column :access_level
+    column :special_attribute
     column :role_id do |record|
       @roles[record.forum_id.to_sym][record.role_id]
     end
@@ -28,20 +24,19 @@ ActiveAdmin.register UnitForumRole do
   form do |f|
     f.semantic_errors *f.object.errors.keys
     f.inputs do
-      input :unit, collection: Unit.active.order(:ancestry, :order)
-      input :access_level, as: :select, collection: UnitForumRole.access_levels.keys
-      input :forum_id, as: :select, collection: UnitForumRole.forum_ids.map(&:reverse)
+      input :special_attribute, as: :select, collection: SpecialForumRole.special_attributes.map(&:reverse)
+      input :forum_id, as: :select, collection: SpecialForumRole.forum_ids.map(&:reverse)
       input :role_id, as: :select, label: 'Discourse role',
                       collection: controller.roles[:discourse].map(&:reverse),
                       input_html: {
-                        name: 'unit_forum_role[discourse_role_id]',
-                        id: 'unit_forum_role_discourse_role_id'
+                        name: 'special_forum_role[discourse_role_id]',
+                        id: 'special_forum_role_discourse_role_id'
                       }
       input :role_id, as: :select, label: 'Vanilla role',
                       collection: controller.roles[:vanilla].map(&:reverse),
                       input_html: {
-                        name: 'unit_forum_role[vanilla_role_id]',
-                        id: 'unit_forum_role_vanilla_role_id'
+                        name: 'special_forum_role[vanilla_role_id]',
+                        id: 'special_forum_role_vanilla_role_id'
                       }
     end
     f.actions
@@ -49,11 +44,11 @@ ActiveAdmin.register UnitForumRole do
     script do
       raw <<~JS
         function showForumRoleInput (forum) {
-          $('#unit_forum_role_discourse_role_id').parent('li').toggle(forum === 'discourse')
-          $('#unit_forum_role_vanilla_role_id').parent('li').toggle(forum === 'vanilla')
+          $('#special_forum_role_discourse_role_id').parent('li').toggle(forum === 'discourse')
+          $('#special_forum_role_vanilla_role_id').parent('li').toggle(forum === 'vanilla')
         }
 
-        forumInput = $('#unit_forum_role_forum_id')
+        forumInput = $('#special_forum_role_forum_id')
         forumInput.on('change', function (evt) {
           showForumRoleInput(evt.target.value)
         })
@@ -63,11 +58,11 @@ ActiveAdmin.register UnitForumRole do
     end
   end
 
-  before_save do |unit_forum_role|
-    if unit_forum_role.discourse?
-      unit_forum_role.role_id = unit_forum_role.discourse_role_id
-    elsif unit_forum_role.vanilla?
-      unit_forum_role.role_id = unit_forum_role.vanilla_role_id
+  before_save do |special_forum_role|
+    if special_forum_role.discourse?
+      special_forum_role.role_id = special_forum_role.discourse_role_id
+    elsif special_forum_role.vanilla?
+      special_forum_role.role_id = special_forum_role.vanilla_role_id
     end
   end
 

--- a/app/admin/unit_forum_roles.rb
+++ b/app/admin/unit_forum_roles.rb
@@ -1,0 +1,82 @@
+ActiveAdmin.register UnitForumRole do
+  permit_params :unit_id, :access_level, :forum_id, :role_id,
+                :discourse_role_id, :vanilla_role_id
+
+  includes :unit
+
+  scope :all, default: true
+  scope :discourse
+  scope :vanilla
+
+  filter :unit, collection: -> { Unit.active.order(:ancestry, :order) }
+  filter :access_level, as: :select, collection: UnitForumRole.access_levels
+  filter :forum_id, as: :select, collection: UnitForumRole.forum_ids
+  filter :role_id
+
+  index do
+    @roles ||= controller.roles
+    selectable_column
+    column :unit
+    column :access_level
+    column :role_id do |record|
+      @roles[record.forum_id.to_sym][record.role_id]
+    end
+    column :forum_id
+    actions
+  end
+
+  form do |f|
+    f.semantic_errors *f.object.errors.keys
+    f.inputs do
+      input :unit, collection: Unit.active.order(:ancestry, :order)
+      input :access_level, as: :select, collection: UnitForumRole.access_levels.keys
+      input :forum_id, as: :select, collection: UnitForumRole.forum_ids.map(&:reverse)
+      input :role_id, as: :select, label: 'Discourse role',
+                      collection: controller.roles[:discourse].map(&:reverse),
+                      input_html: {
+                        name: 'unit_forum_role[discourse_role_id]',
+                        id: 'unit_forum_role_discourse_role_id'
+                      }
+      input :role_id, as: :select, label: 'Vanilla role',
+                      collection: controller.roles[:vanilla].map(&:reverse),
+                      input_html: {
+                        name: 'unit_forum_role[vanilla_role_id]',
+                        id: 'unit_forum_role_vanilla_role_id'
+                      }
+    end
+    f.actions
+
+    script do
+      raw <<~JS
+        function showForumRoleInput (forum) {
+          $('#unit_forum_role_discourse_role_id').parent('li').toggle(forum === 'discourse')
+          $('#unit_forum_role_vanilla_role_id').parent('li').toggle(forum === 'vanilla')
+        }
+
+        forumInput = $('#unit_forum_role_forum_id')
+        forumInput.on('change', function (evt) {
+          showForumRoleInput(evt.target.value)
+        })
+
+        showForumRoleInput(forumInput.val())
+      JS
+    end
+  end
+
+  before_save do |unit_forum_role|
+    if unit_forum_role.discourse?
+      unit_forum_role.role_id = unit_forum_role.discourse_role_id
+    elsif unit_forum_role.vanilla?
+      unit_forum_role.role_id = unit_forum_role.vanilla_role_id
+    end
+  end
+
+  controller do
+    def roles
+      @roles ||= {
+        discourse: DiscourseService.new().get_roles,
+        vanilla: VanillaService.new().get_roles
+      }
+    end
+  end
+end

--- a/app/models/special_forum_role.rb
+++ b/app/models/special_forum_role.rb
@@ -1,0 +1,20 @@
+class SpecialForumRole < ApplicationRecord
+  self.table_name = 'special_roles'
+
+  enum special_attribute: {
+    'everyone': 'everyone',
+    'member': 'member',
+    'officer': 'officer',
+    'honorably_discharged': 'honorably_discharged',
+  }
+
+  enum forum_id: { vanilla: 'Vanilla',
+                   discourse: 'Discourse' }
+
+  validates :special_attribute, presence: true
+  validates :forum_id, presence: true
+  validates :role_id, presence: true
+  validates :role_id, numericality: { only_integer: true }
+
+  attr_accessor :discourse_role_id, :vanilla_role_id
+  end

--- a/app/models/unit_forum_role.rb
+++ b/app/models/unit_forum_role.rb
@@ -4,9 +4,7 @@ class UnitForumRole < ApplicationRecord
 
   enum access_level: { member: 0, elevated: 5, leader: 10 }
 
-  enum forum_id: { phpbb: 'PHPBB',
-                   smf: 'SMF',
-                   vanilla: 'Vanilla',
+  enum forum_id: { vanilla: 'Vanilla',
                    discourse: 'Discourse' }
 
   validates :forum_id, presence: true

--- a/app/models/unit_forum_role.rb
+++ b/app/models/unit_forum_role.rb
@@ -1,0 +1,18 @@
+class UnitForumRole < ApplicationRecord
+  self.table_name = 'unit_roles'
+  belongs_to :unit
+
+  enum access_level: { member: 0, elevated: 5, leader: 10 }
+
+  enum forum_id: { phpbb: 'PHPBB',
+                   smf: 'SMF',
+                   vanilla: 'Vanilla',
+                   discourse: 'Discourse' }
+
+  validates :forum_id, presence: true
+  validates :access_level, presence: true
+  validates :role_id, presence: true
+  validates :role_id, numericality: { only_integer: true }
+
+  attr_accessor :discourse_role_id, :vanilla_role_id
+end

--- a/app/policies/special_forum_role_policy.rb
+++ b/app/policies/special_forum_role_policy.rb
@@ -1,0 +1,21 @@
+class SpecialForumRolePolicy < ApplicationPolicy
+  def index?
+    user&.has_permission?('admin')
+  end
+
+  def show?
+    user&.has_permission?('admin')
+  end
+
+  def create?
+    user&.has_permission?('admin')
+  end
+
+  def update?
+    user&.has_permission?('admin')
+  end
+
+  def destroy?
+    user&.has_permission?('admin')
+  end
+end

--- a/app/policies/unit_forum_role_policy.rb
+++ b/app/policies/unit_forum_role_policy.rb
@@ -1,0 +1,21 @@
+class UnitForumRolePolicy < ApplicationPolicy
+  def index?
+    user&.has_permission?('admin')
+  end
+
+  def show?
+    user&.has_permission?('admin')
+  end
+
+  def create?
+    user&.has_permission?('admin')
+  end
+
+  def update?
+    user&.has_permission?('admin')
+  end
+
+  def destroy?
+    user&.has_permission?('admin')
+  end
+end

--- a/app/services/discourse_service.rb
+++ b/app/services/discourse_service.rb
@@ -1,0 +1,16 @@
+class DiscourseService
+  include HTTParty
+  base_uri ENV['DISCOURSE_BASE_URL']
+  headers 'Api-Key' => ENV['DISCOURSE_API_KEY']
+  headers 'Api-Username' => 'system'
+
+  def get_roles()
+    response = self.class.get('/groups.json')
+    return if response.body.nil? || response.body.empty?
+
+    response['groups'].reduce({}) do |accum, role|
+      accum[role['id']] = role['name']
+      accum
+    end
+  end
+end

--- a/app/services/vanilla_service.rb
+++ b/app/services/vanilla_service.rb
@@ -1,0 +1,16 @@
+class VanillaService
+  include HTTParty
+  # base_uri ENV['VANILLA_BASE_URL'] + '/api/v2'
+  base_uri 'http://forums/api/v2'
+  headers 'Authorization' => "Bearer #{ENV['VANILLA_API_KEY']}"
+
+  def get_roles()
+    response = self.class.get('/roles')
+    return if response.body.nil? || response.body.empty?
+
+    response.reduce({}) do |accum, role|
+      accum[role['roleID']] = role['name']
+      accum
+    end
+  end
+end

--- a/app/services/vanilla_service.rb
+++ b/app/services/vanilla_service.rb
@@ -1,7 +1,6 @@
 class VanillaService
   include HTTParty
-  # base_uri ENV['VANILLA_BASE_URL'] + '/api/v2'
-  base_uri 'http://forums/api/v2'
+  base_uri ENV['VANILLA_BASE_URL'] + '/api/v2'
   headers 'Authorization' => "Bearer #{ENV['VANILLA_API_KEY']}"
 
   def get_roles()

--- a/db/migrate/20201121125507_add_forum_id_to_unit_roles.rb
+++ b/db/migrate/20201121125507_add_forum_id_to_unit_roles.rb
@@ -1,0 +1,16 @@
+class AddForumIdToUnitRoles < ActiveRecord::Migration[6.0]
+  def up
+    add_column :unit_roles, :forum_id,
+               "enum('Vanilla','Discourse')",
+               null: false
+
+    execute <<~SQL
+      UPDATE unit_roles
+        SET forum_id = 'Vanilla';
+    SQL
+  end
+
+  def down
+    remove_column :unit_roles, :forum_id
+  end
+end

--- a/db/migrate/20201122132332_add_special_roles.rb
+++ b/db/migrate/20201122132332_add_special_roles.rb
@@ -1,0 +1,10 @@
+class AddSpecialRoles < ActiveRecord::Migration[6.0]
+  def change
+    create_table :special_roles do |t|
+      t.string :special_attribute, null: false
+      t.integer :role_id, null: false
+      t.column :forum_id, "enum('Vanilla','Discourse')",
+                          null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_29_073647) do
+ActiveRecord::Schema.define(version: 2020_11_21_125507) do
 
   create_table "__att1", id: :integer, limit: 3, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", comment: "Log of attendance", force: :cascade do |t|
     t.integer "event_id", limit: 3, null: false, comment: "Event ID", unsigned: true
@@ -195,12 +195,12 @@ ActiveRecord::Schema.define(version: 2020_10_29_073647) do
   create_table "events", id: :integer, limit: 3, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "datetime", null: false
     t.integer "unit_id", limit: 3, unsigned: true
-    t.string "title", limit: 64, null: false
+    t.string "title", limit: 64
     t.string "type", limit: 32, null: false
     t.boolean "mandatory", default: false, null: false
-    t.string "server", limit: 32, null: false
+    t.string "server", limit: 32
     t.integer "server_id", limit: 3, unsigned: true
-    t.text "report", null: false
+    t.text "report"
     t.integer "reporter_member_id", limit: 3, unsigned: true
     t.datetime "report_posting_date", comment: "Date of AAR posting"
     t.datetime "report_edit_date", comment: "Date of last AAR editing"
@@ -377,6 +377,7 @@ ActiveRecord::Schema.define(version: 2020_10_29_073647) do
     t.integer "unit_id", limit: 3, unsigned: true
     t.integer "access_level", limit: 2, default: 0, null: false
     t.integer "role_id", limit: 3, null: false, unsigned: true
+    t.column "forum_id", "enum('Vanilla','Discourse')", null: false
     t.index ["unit_id", "role_id"], name: "unit_id", unique: true
   end
 
@@ -388,7 +389,7 @@ ActiveRecord::Schema.define(version: 2020_10_29_073647) do
     t.integer "order", default: 0, null: false
     t.column "game", "enum('DH','RS','Arma 3','RS2','Squad')", comment: "Game "
     t.string "timezone", limit: 3
-    t.column "class", "enum('Combat','Staff','Training')", default: "Training", null: false
+    t.column "class", "enum('Combat','Staff','Training')", default: "Training", null: false, comment: "Type of unit"
     t.boolean "active", default: true, null: false
     t.string "steam_group_abbr", limit: 30, comment: "Abbreviation of Unit's Steam Group"
     t.string "slogan", limit: 200, comment: "Unit's Slogan"
@@ -404,7 +405,7 @@ ActiveRecord::Schema.define(version: 2020_10_29_073647) do
     t.string "session_id", limit: 100, null: false
     t.string "user_identifier", null: false
     t.text "request_uri", null: false
-    t.string "request_method", limit: 16, null: false
+    t.text "request_method", null: false
     t.datetime "datetime", null: false
     t.string "client_ip", limit: 50, null: false
     t.text "client_user_agent", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -195,12 +195,12 @@ ActiveRecord::Schema.define(version: 2020_11_22_132332) do
   create_table "events", id: :integer, limit: 3, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "datetime", null: false
     t.integer "unit_id", limit: 3, unsigned: true
-    t.string "title", limit: 64
+    t.string "title", limit: 64, null: false
     t.string "type", limit: 32, null: false
     t.boolean "mandatory", default: false, null: false
-    t.string "server", limit: 32
+    t.string "server", limit: 32, null: false
     t.integer "server_id", limit: 3, unsigned: true
-    t.text "report"
+    t.text "report", null: false
     t.integer "reporter_member_id", limit: 3, unsigned: true
     t.datetime "report_posting_date", comment: "Date of AAR posting"
     t.datetime "report_edit_date", comment: "Date of last AAR editing"
@@ -395,7 +395,7 @@ ActiveRecord::Schema.define(version: 2020_11_22_132332) do
     t.integer "order", default: 0, null: false
     t.column "game", "enum('DH','RS','Arma 3','RS2','Squad')", comment: "Game "
     t.string "timezone", limit: 3
-    t.column "class", "enum('Combat','Staff','Training')", default: "Training", null: false, comment: "Type of unit"
+    t.column "class", "enum('Combat','Staff','Training')", default: "Training", null: false
     t.boolean "active", default: true, null: false
     t.string "steam_group_abbr", limit: 30, comment: "Abbreviation of Unit's Steam Group"
     t.string "slogan", limit: 200, comment: "Unit's Slogan"
@@ -411,7 +411,7 @@ ActiveRecord::Schema.define(version: 2020_11_22_132332) do
     t.string "session_id", limit: 100, null: false
     t.string "user_identifier", null: false
     t.text "request_uri", null: false
-    t.text "request_method", null: false
+    t.string "request_method", limit: 16, null: false
     t.datetime "datetime", null: false
     t.string "client_ip", limit: 50, null: false
     t.text "client_user_agent", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_21_125507) do
+ActiveRecord::Schema.define(version: 2020_11_22_132332) do
 
   create_table "__att1", id: :integer, limit: 3, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", comment: "Log of attendance", force: :cascade do |t|
     t.integer "event_id", limit: 3, null: false, comment: "Event ID", unsigned: true
@@ -354,6 +354,12 @@ ActiveRecord::Schema.define(version: 2020_11_21_125507) do
     t.column "game", "enum('DH','Arma 3','RS','RS2','Squad')", default: "DH", null: false, comment: "Type of game "
     t.boolean "active", null: false, comment: "Is server active"
     t.string "battle_metrics_id", limit: 16
+  end
+
+  create_table "special_roles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.string "special_attribute", null: false
+    t.integer "role_id", null: false
+    t.column "forum_id", "enum('Vanilla','Discourse')", null: false
   end
 
   create_table "standards", id: :integer, limit: 3, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", comment: "Standards required to achieve a badge for AIT", force: :cascade do |t|

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -116,7 +116,14 @@ FactoryBot.define do
   end
 
   factory :unit_forum_role do
+    unit
     access_level { :member }
+    forum_id { :discourse }
+    role_id { Faker::Number.number(digits: 2) }
+  end
+
+  factory :special_forum_role do
+    special_attribute { :everyone }
     forum_id { :discourse }
     role_id { Faker::Number.number(digits: 2) }
   end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -114,4 +114,10 @@ FactoryBot.define do
     address { '0.0.0.0' }
     game { :rs2 }
   end
+
+  factory :unit_forum_role do
+    access_level { :member }
+    forum_id { :discourse }
+    role_id { Faker::Number.number(digits: 2) }
+  end
 end


### PR DESCRIPTION
This lets us edit the `unit_roles` table for both vanilla and discourse roles. It also adds a new model/table called `special_roles` that replaces `class_roles` with the ability to add hard-coded logic like "member", "officer", "honorably discharged", etc.