### PR TITLE
Enable audit logging on all models via audited gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,3 +83,4 @@ gem 'aws-sdk-s3', '~> 1.14', require: false
 gem 'image_processing', '~> 1.0'
 gem 'fastimage', '~> 2.2', '>= 2.2.2'
 gem 'flag-icons-rails', '~> 3.4', '>= 3.4.6.1'
+gem 'audited', '~> 4.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,8 @@ GEM
     arbre (1.4.0)
       activesupport (>= 3.0.0, < 6.2)
       ruby2_keywords (>= 0.0.2, < 1.0)
+    audited (4.10.0)
+      activerecord (>= 4.2, < 6.2)
     autoprefixer-rails (10.0.0.2)
       execjs
     aws-eventstream (1.1.0)
@@ -344,6 +346,7 @@ DEPENDENCIES
   activeadmin (~> 2.9)
   activeadmin_addons (~> 1.7, >= 1.7.1)
   ancestry (~> 3.2, >= 3.2.1)
+  audited (~> 4.10)
   aws-sdk-s3 (~> 1.14)
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.4.1)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,5 +1,6 @@
 class Ability < ApplicationRecord
   has_many :permissions
+  audited
 
   validates_presence_of :name, :abbr
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,4 +1,5 @@
 class Assignment < ApplicationRecord
+  audited
   belongs_to :unit
   belongs_to :user, foreign_key: 'member_id'
   belongs_to :position

--- a/app/models/award.rb
+++ b/app/models/award.rb
@@ -1,4 +1,5 @@
 class Award < ApplicationRecord
+  audited
   include AwardImageUploader::Attachment(:presentation_image)
   include AwardImageUploader::Attachment(:ribbon_image)
 

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,4 +1,5 @@
 class Note < ApplicationRecord
+  audited max_audits: 10
   belongs_to :user, foreign_key: 'member_id'
   belongs_to :author, class_name: 'User', foreign_key: 'author_member_id'
 

--- a/app/models/pass.rb
+++ b/app/models/pass.rb
@@ -1,5 +1,6 @@
 class Pass < ApplicationRecord
   self.inheritance_column = nil # don't treat type field as STI
+  audited
   belongs_to :user, foreign_key: 'member_id'
   belongs_to :author, class_name: 'User'
   belongs_to :recruit, class_name: 'User', optional: true

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,5 +1,6 @@
 class Permission < ApplicationRecord
   self.table_name = 'unit_permissions'
+  audited
   enum access_level: { member: 0, elevated: 5, leader: 10 }
 
   belongs_to :unit

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -1,4 +1,5 @@
 class Position < ApplicationRecord
+  audited
   enum access_level: { member: 0, elevated: 5, leader: 10 }
 
   scope :active, -> { where(active: true ) }

--- a/app/models/rank.rb
+++ b/app/models/rank.rb
@@ -1,4 +1,5 @@
 class Rank < ApplicationRecord
+  audited
   include RankImageUploader::Attachment(:image)
 
   validates_presence_of :name, :abbr, :order

--- a/app/models/special_forum_role.rb
+++ b/app/models/special_forum_role.rb
@@ -1,4 +1,5 @@
 class SpecialForumRole < ApplicationRecord
+  audited
   self.table_name = 'special_roles'
 
   enum special_attribute: {

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -1,4 +1,5 @@
 class Unit < ApplicationRecord
+  audited max_audits: 10
   include UnitLogoImageUploader::Attachment(:logo)
 
   has_ancestry orphan_strategy: :restrict

--- a/app/models/unit_forum_role.rb
+++ b/app/models/unit_forum_role.rb
@@ -1,4 +1,5 @@
 class UnitForumRole < ApplicationRecord
+  audited
   self.table_name = 'unit_roles'
   belongs_to :unit
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   self.table_name = 'members'
+  audited max_audits: 10
 
   has_many :assignments, dependent: :delete_all, foreign_key: 'member_id'
   has_many :units, through: :assignments

--- a/app/models/user_award.rb
+++ b/app/models/user_award.rb
@@ -1,4 +1,5 @@
 class UserAward < ApplicationRecord
+  audited
   self.table_name = 'awardings'
   belongs_to :user, foreign_key: 'member_id'
   belongs_to :award

--- a/db/migrate/20210305073013_install_audited.rb
+++ b/db/migrate/20210305073013_install_audited.rb
@@ -1,0 +1,30 @@
+class InstallAudited < ActiveRecord::Migration[6.0]
+  def self.up
+    create_table :audits, :force => true do |t|
+      t.column :auditable_id, :integer
+      t.column :auditable_type, :string
+      t.column :associated_id, :integer
+      t.column :associated_type, :string
+      t.column :user_id, :integer
+      t.column :user_type, :string
+      t.column :username, :string
+      t.column :action, :string
+      t.column :audited_changes, :json
+      t.column :version, :integer, :default => 0
+      t.column :comment, :string
+      t.column :remote_address, :string
+      t.column :request_uuid, :string
+      t.column :created_at, :datetime
+    end
+
+    add_index :audits, [:auditable_type, :auditable_id, :version], :name => 'auditable_index'
+    add_index :audits, [:associated_type, :associated_id], :name => 'associated_index'
+    add_index :audits, [:user_id, :user_type], :name => 'user_index'
+    add_index :audits, :request_uuid
+    add_index :audits, :created_at
+  end
+
+  def self.down
+    drop_table :audits
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_26_064745) do
+ActiveRecord::Schema.define(version: 2021_03_05_073013) do
 
   create_table "__att1", id: :integer, limit: 3, unsigned: true, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", comment: "Log of attendance", force: :cascade do |t|
     t.integer "event_id", limit: 3, null: false, comment: "Event ID", unsigned: true
@@ -67,6 +67,28 @@ ActiveRecord::Schema.define(version: 2021_02_26_064745) do
     t.index ["event_id", "member_id"], name: "event and member", unique: true
     t.index ["event_id"], name: "Event ID"
     t.index ["member_id"], name: "User ID"
+  end
+
+  create_table "audits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
+    t.integer "auditable_id"
+    t.string "auditable_type"
+    t.integer "associated_id"
+    t.string "associated_type"
+    t.integer "user_id"
+    t.string "user_type"
+    t.string "username"
+    t.string "action"
+    t.json "audited_changes"
+    t.integer "version", default: 0
+    t.string "comment"
+    t.string "remote_address"
+    t.string "request_uuid"
+    t.datetime "created_at"
+    t.index ["associated_type", "associated_id"], name: "associated_index"
+    t.index ["auditable_type", "auditable_id", "version"], name: "auditable_index"
+    t.index ["created_at"], name: "index_audits_on_created_at"
+    t.index ["request_uuid"], name: "index_audits_on_request_uuid"
+    t.index ["user_id", "user_type"], name: "user_index"
   end
 
   create_table "awardings", id: :integer, limit: 3, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
Closes 29th/personnel#476

I'd like to display the change log following something like [this tutorial](https://github.com/activeadmin/activeadmin/wiki/Auditing-via-paper_trail-%28change-history%29), but at least this PR starts recording the logs, which is mergable.