### PR TITLE
Support adding multiple events in admin

### DIFF
--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -2,7 +2,7 @@ ActiveAdmin.register Event do
   includes :unit
   includes :server
 
-  permit_params :datetime, :unit_id, :type, :mandatory, :server_id
+  permit_params :bulk_dates, :time, :unit_id, :type, :mandatory, :server_id
 
   filter :datetime
   filter :unit, collection: -> { Unit.for_dropdown }
@@ -19,7 +19,15 @@ ActiveAdmin.register Event do
   form do |f|
     f.semantic_errors(*f.object.errors.attribute_names)
     f.inputs do
-      input :datetime, as: :date_time_picker, label: "Start time"
+      if f.object.persisted?
+        input :datetime, as: :date_time_picker, label: "Start time"
+      else
+        input :bulk_dates, as: :date_picker, label: "Date(s)", input_html: {
+          "data-controller": "flatpickr",
+          "data-flatpickr-mode": "multiple"
+        }
+        input :time, as: :time_picker
+      end
       input :unit, collection: Unit.for_dropdown
       input :type, as: :select, collection: Event::TYPES
       input :server, collection: Server.for_dropdown.map { |server| ["#{Server.games[server.game]} - #{server.name}", server.id] }
@@ -29,7 +37,6 @@ ActiveAdmin.register Event do
   end
 
   show do
-    # TODO: Support multiple dates, like passes
     attributes_table do
       row("Start time") { |row| row.datetime }
       row :unit
@@ -51,4 +58,45 @@ ActiveAdmin.register Event do
 
   config.sort_order = "datetime_desc"
   config.create_another = true
+
+  # Allow creating multiple events at once
+  # See: https://github.com/activeadmin/inherited_resources#overwriting-actions
+  controller do
+    def create
+      bulk_dates = permitted_params[:event][:bulk_dates].split(", ").first(20) # Restrict over-loading
+      base_event = build_resource # ActiveAdmin method. Applies authorization etc.
+
+      resource_class.transaction do
+        bulk_dates.each do |date|
+          @event = base_event.dup
+          @event.date = date
+          create_resource!(@event)
+        end
+      end
+
+      count = bulk_dates.count
+      location = count === 1 ? smart_resource_url : smart_collection_url
+      redirect_to location, notice: batch_created_notice(count)
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::Rollback
+      render :new
+    end
+
+    # copied from active_admin and inherited_resources, with ! added to save
+    def create_resource!(object)
+      run_create_callbacks object do
+        run_save_callbacks object do
+          object.save!
+        end
+      end
+    end
+
+    def batch_created_notice(count)
+      I18n.t(
+        "active_admin.batch_actions.successfully_created",
+        count: count,
+        model: active_admin_config.resource_label.downcase,
+        plural_model: active_admin_config.plural_resource_label(count: count).downcase
+      )
+    end
+  end
 end

--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -31,7 +31,7 @@ ActiveAdmin.register Event do
   show do
     # TODO: Support multiple dates, like passes
     attributes_table do
-      row "Start time", :datetime
+      row("Start time") { |row| row.datetime }
       row :unit
       row :type
       row :server

--- a/app/javascript/packs/active_admin.js
+++ b/app/javascript/packs/active_admin.js
@@ -1,5 +1,6 @@
 import { Application } from 'stimulus'
 import { definitionsFromContext } from 'stimulus/webpack-helpers'
+import StimulusFlatpickr from 'stimulus-flatpickr'
 import '@activeadmin/activeadmin'
 import 'activeadmin_addons'
 
@@ -8,3 +9,4 @@ import '../stylesheets/active_admin'
 const application = Application.start()
 const context = require.context('../src/controllers', true, /\.js$/)
 application.load(definitionsFromContext(context))
+application.register('flatpickr', StimulusFlatpickr)

--- a/app/javascript/stylesheets/active_admin.scss
+++ b/app/javascript/stylesheets/active_admin.scss
@@ -11,6 +11,7 @@
 @import "~activeadmin_addons/src/stylesheets/all";
 @import "~@activeadmin/activeadmin/src/scss/mixins";
 @import "~@activeadmin/activeadmin/src/scss/base";
+@import "~flatpickr";
 
 // Overriding any non-variable Sass must be done after the fact.
 // For example, to change the default status-tag color:

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,12 +16,16 @@ class Event < ApplicationRecord
     where(unit: unit_ids)
   end
 
+  attr_accessor :bulk_dates
+  attr_writer :time
+
   TYPES = ["Squad Drills", "Platoon Drills", "Company Drills", "Battalion Drills", "Basic Combat Training",
     "Public Scrimmage", "Special Event"]
   validates :type, presence: true, inclusion: {in: TYPES}
 
   validates :datetime, presence: true
   validates_datetime :datetime
+  validates_time :time
   validates :mandatory, inclusion: {in: [true, false]}
   validates :server, presence: true
 
@@ -85,6 +89,20 @@ class Event < ApplicationRecord
     else
       attendance_record.update(excused: false)
     end
+  end
+
+  def date=(date)
+    parsed_date = begin
+      Date.parse(date)
+    rescue
+      return
+    end
+
+    self.datetime = Time.parse(time, parsed_date) if time
+  end
+
+  def time
+    @time || datetime&.strftime("%T")
   end
 
   private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,3 +12,8 @@ en:
   simple_calendar:
     previous: "<"
     next: ">"
+  active_admin:
+    batch_actions:
+      successfully_created:
+        one: "Successfully created 1 %{model}"
+        other: "Successfully created %{count} %{plural_model}"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "axios": "^0.21.1",
     "bootstrap.native": "^2.0.23",
     "choices.js": "~9.0.1",
-    "stimulus": "^2.0.0"
+    "flatpickr": "^4.6.13",
+    "stimulus": "^2.0.0",
+    "stimulus-flatpickr": "^1.4.0"
   },
   "devDependencies": {
     "webpack-dev-server": "^3.11.2"

--- a/test/admin/admin_events_controller_test.rb
+++ b/test/admin/admin_events_controller_test.rb
@@ -1,0 +1,145 @@
+require "test_helper"
+
+class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    user = create(:user)
+    unit = create(:unit)
+    server = create(:server)
+    create(:permission, :elevated, abbr: "event_add", unit: unit)
+    create(:assignment, :elevated, user: user, unit: unit)
+    sign_in_as user
+
+    @event = build(:event, unit: unit, server: server)
+  end
+
+  test "should create one event" do
+    assert_difference("Event.count", 1) do
+      post admin_events_url, params: {
+        event: {
+          bulk_dates: 1.day.from_now.strftime("%F"),
+          time: "18:00",
+          unit_id: @event.unit_id,
+          type: @event.type,
+          server_id: @event.server.id,
+          mandatory: @event.mandatory
+        }
+      }
+    end
+
+    assert_redirected_to admin_event_url(Event.last)
+  end
+
+  test "should create multiple events" do
+    dates = [
+      1.week.from_now,
+      2.weeks.from_now,
+      3.weeks.from_now
+    ]
+    bulk_dates = dates.map { |date| date.strftime("%F") }.join(", ")
+
+    assert_difference("Event.count", dates.size) do
+      post admin_events_url, params: {
+        event: {
+          bulk_dates: bulk_dates,
+          time: "18:00",
+          unit_id: @event.unit_id,
+          type: @event.type,
+          server_id: @event.server.id,
+          mandatory: @event.mandatory
+        }
+      }
+    end
+
+    assert_redirected_to admin_events_url
+  end
+
+  test "should fail and show errors if invalid" do
+    assert_difference("Event.count", 0) do
+      post admin_events_url, params: {
+        event: {
+          bulk_dates: 1.day.from_now.strftime("%F"),
+          time: "18:00",
+          unit_id: @event.unit_id,
+          type: @event.type,
+          server_id: "", # fail validation
+          mandatory: @event.mandatory
+        }
+      }
+    end
+
+    assert_response :success
+    assert_select ".errors li"
+  end
+
+  test "should fail if not authorized" do
+    other_unit = create(:unit)
+    assert_difference("Event.count", 0) do
+      post admin_events_url, params: {
+        event: {
+          bulk_dates: 1.day.from_now.strftime("%F"),
+          time: "18:00",
+          unit_id: other_unit.id,
+          type: @event.type,
+          server_id: @event.server.id,
+          mandatory: @event.mandatory
+        }
+      }
+    end
+
+    assert_redirected_to admin_root_url
+  end
+
+  test "should create 20 events maximum" do
+    bulk_dates = (Date.today..21.days.from_now)
+      .map { |date| date.strftime("%F") }
+      .join(", ")
+
+    assert_difference("Event.count", 20) do
+      post admin_events_url, params: {
+        event: {
+          bulk_dates: bulk_dates,
+          time: "18:00",
+          unit_id: @event.unit_id,
+          type: @event.type,
+          server_id: @event.server.id,
+          mandatory: @event.mandatory
+        }
+      }
+    end
+  end
+
+  test "should fail on invalid bulk date format" do
+    bulk_dates = "foo, bar"
+    assert_difference("Event.count", 0) do
+      post admin_events_url, params: {
+        event: {
+          bulk_dates: bulk_dates,
+          time: "18:00",
+          unit_id: @event.unit_id,
+          type: @event.type,
+          server_id: @event.server.id,
+          mandatory: @event.mandatory
+        }
+      }
+    end
+  end
+
+  test "should fail and show errors if form is empty" do
+    skip
+    assert_difference("Event.count", 0) do
+      post admin_events_url, params: {
+        event: {
+          bulk_dates: "",
+          time: "",
+          unit_id: "",
+          type: "",
+          server_id: "",
+          mandatory: "0"
+        }
+      }
+    end
+
+    assert_response :success # as opposed to redirection
+    assert_select ".errors li"
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -3061,6 +3061,11 @@ findup-sync@^3.0.0:
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
+flatpickr@^4.6.13:
+  version "4.6.13"
+  resolved "https://registry.yarnpkg.com/flatpickr/-/flatpickr-4.6.13.tgz#8a029548187fd6e0d670908471e43abe9ad18d94"
+  integrity sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw==
+
 flatted@^3.2.2:
   version "3.2.5"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
@@ -6409,6 +6414,11 @@ statuses@2.0.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
+
+stimulus-flatpickr@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/stimulus-flatpickr/-/stimulus-flatpickr-1.4.0.tgz#a41071a3e69cfc50b7eaaacf356fc0ab1ab0543c"
+  integrity sha512-rcC/c9+E+f5W2kOjaaLShtf3i+p95ACqt+oGzSAgeuZh2YeIN8gW4EWO7h0STBLzSVPl6BjIfPWP7upMPavIVQ==
 
 stimulus@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Overrides the controller action in inherited_resources
See: https://github.com/activeadmin/inherited_resources#overwriting-actions
I tried to reuse existing active_admin/inherited_resources methods where possible and keep it generic, so that it can be abstracted to a module that can be included (e.g. for passes)