### PR TITLE
Gracefully handle unauthorised requests originating from another host

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,6 @@
 class EventsController < ApplicationController
+  before_action :authenticate_user!
+
   def index
     authorize Event
 

--- a/app/controllers/passes_controller.rb
+++ b/app/controllers/passes_controller.rb
@@ -1,4 +1,6 @@
 class PassesController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show]
+
   def index
     authorize Pass
     @query = Pass.ransack(params[:q])

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,7 +15,8 @@ class SessionsController < ApplicationController
 
   def destroy
     reset_session
-    redirect_back fallback_location: root_url, notice: "Signed out!"
+    redirect_back fallback_location: root_url, allow_other_host: false,
+      notice: "Signed out!"
   end
 
   def failure

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,5 +1,10 @@
 module SessionsHelper
-  def signin_path(provider)
-    "/auth/#{provider}"
+  def sign_in_path(provider, origin)
+    path = "/auth/#{provider}"
+    if origin
+      "#{path}?origin=#{origin}"
+    else
+      path
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,6 +76,17 @@ class User < ApplicationRecord
     permissions_on_user(user).pluck("abilities.abbr").include?(permission)
   end
 
+  # Checks whether user has :new? permission on any active admin resources
+  def active_admin_editor?
+    namespace = ActiveAdmin.application.default_namespace
+    resources = ActiveAdmin.application.namespaces[namespace].resources
+    resource_classes = resources.grep(ActiveAdmin::Resource).map(&:resource_class)
+    resource_classes -= [Enlistment]
+    resource_classes.any? do |resource_class|
+      Pundit.policy(self, resource_class)&.new?
+    end
+  end
+
   def member?
     @member ||= assignments.active
       .joins(:unit)

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -37,7 +37,9 @@
           </li>
           <% else %>
           <li class="nav-item">
-            <%= link_to 'Sign in', signin_path(:discourse), method: :post, class: 'nav-link' %>
+            <%= link_to 'Sign in', sign_in_path(:discourse, flash[:sign_in_origin]),
+                  method: :post, class: 'nav-link' %>
+          </li>
           <% end %>
         </ul>
       </div>

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -79,7 +79,7 @@ ActiveAdmin.setup do |config|
   # because, by default, user gets redirected to Dashboard. If user
   # doesn't have access to Dashboard, he'll end up in a redirect loop.
   # Method provided here should be defined in application_controller.rb.
-  # config.on_unauthorized_access = :access_denied
+  config.on_unauthorized_access = :user_not_authorized
 
   # == Current User
   #

--- a/test/admin/admin_events_controller_test.rb
+++ b/test/admin/admin_events_controller_test.rb
@@ -83,10 +83,10 @@ class Admin::EventsControllerTest < ActionDispatch::IntegrationTest
           server_id: @event.server.id,
           mandatory: @event.mandatory
         }
-      }
+      }, headers: {HTTP_REFERER: new_admin_event_url}
     end
 
-    assert_redirected_to admin_root_url
+    assert_redirected_to new_admin_event_url
   end
 
   test "should create 20 events maximum" do

--- a/test/admin/assignments_controller_test.rb
+++ b/test/admin/assignments_controller_test.rb
@@ -51,7 +51,7 @@ class Admin::AssignmentsControllerTest < ActionDispatch::IntegrationTest
       post admin_assignments_url, params: {assignment: assignment_attributes(assignment)}
     end
 
-    assert_equal "You are not authorized to perform this action.", flash[:error]
+    assert_equal "You are not authorized to perform this action.", flash[:alert]
   end
 
   test "should end old assignment if transfer_from_unit is in scope" do

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -41,4 +41,12 @@ class ApplicationControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_url
     assert_equal "Authentication error: Invalid credentials", flash[:alert]
   end
+
+  test "accessing a private resource when not signed in redirects back unless it's another host" do
+    get events_url, headers: {HTTP_REFERER: about_url}
+    assert_redirected_to about_url
+
+    get events_url, headers: {HTTP_REFERER: "https://google.com"}
+    assert_redirected_to root_url
+  end
 end


### PR DESCRIPTION
If you try to access a resource that you're unauthorised for, it will redirect you "back", unless "back" is another host/domain, in which case it will redirect you to the homepage, so that it can display the error message that you're not authorised.

If you're not signed in in the first place, it will do the same, but with a message about signing in. And the sign in link will include `?origin=the_url_you_were_trying_to_reach` so you get redirected there once you do sign in.