### PR TITLE
Upgrade activeadmin and ransack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,14 +70,14 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem "pundit", "~> 2.1"
 gem "bootstrap", "~> 4.6"
 gem "kaminari", "~> 1.2", ">= 1.2.1"
-gem "activeadmin", "~> 2.14.0"
+gem "activeadmin", "~> 3.1.0"
 gem "nilify_blanks", "~> 1.4"
 gem "ancestry", "~> 3.2", ">= 3.2.1"
 gem "jwt", "~> 2.2", ">= 2.2.2"
 gem "validates_timeliness", github: "mitsuru/validates_timeliness", branch: "rails7" # until upstream merges PR#213
-gem "activeadmin_addons", "~> 1.7", ">= 1.7.1"
+gem "activeadmin_addons", "~> 1.10", ">= 1.10.1"
 gem "simple_form", "~> 5.1"
-gem "ransack", "~> 2.4", ">= 2.4.2"
+gem "ransack", "~> 4.1", ">= 4.1.1"
 gem 'simple_calendar', '~> 2.0'
 gem "redcarpet", "~> 3.5", ">= 3.5.1"
 gem "shrine", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,15 +66,15 @@ GEM
       actionpack
       addressable
     active_material (1.5.2)
-    activeadmin (2.14.0)
+    activeadmin (3.1.0)
       arbre (~> 1.2, >= 1.2.1)
-      formtastic (>= 3.1, < 5.0)
-      formtastic_i18n (~> 0.4)
+      formtastic (>= 3.1)
+      formtastic_i18n (>= 0.4)
       inherited_resources (~> 1.7)
-      jquery-rails (~> 4.2)
-      kaminari (~> 1.0, >= 1.2.1)
-      railties (>= 6.1, < 7.1)
-      ransack (>= 2.1.1, < 4)
+      jquery-rails (>= 4.2)
+      kaminari (>= 1.2.1)
+      railties (>= 6.1)
+      ransack (>= 4.0)
     activeadmin_addons (1.10.1)
       active_material
       railties
@@ -199,8 +199,8 @@ GEM
       sass-rails
     font-awesome-sass (6.2.1)
       sassc (~> 2.0)
-    formtastic (4.0.0)
-      actionpack (>= 5.2.0)
+    formtastic (5.0.0)
+      actionpack (>= 6.0.0)
     formtastic_i18n (0.7.0)
     friendly_id (5.5.1)
       activerecord (>= 4.0.0)
@@ -345,9 +345,9 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.1.0)
-    ransack (2.6.0)
-      activerecord (>= 6.0.4)
-      activesupport (>= 6.0.4)
+    ransack (4.1.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
       i18n
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -481,8 +481,8 @@ PLATFORMS
 
 DEPENDENCIES
   active_link_to (~> 1.0, >= 1.0.5)
-  activeadmin (~> 2.14.0)
-  activeadmin_addons (~> 1.7, >= 1.7.1)
+  activeadmin (~> 3.1.0)
+  activeadmin_addons (~> 1.10, >= 1.10.1)
   ancestry (~> 3.2, >= 3.2.1)
   appsignal (~> 3.1, >= 3.1.5)
   audited (~> 5.0)
@@ -521,7 +521,7 @@ DEPENDENCIES
   puma (~> 5.0)
   pundit (~> 2.1)
   rails (~> 7.0.4)
-  ransack (~> 2.4, >= 2.4.2)
+  ransack (~> 4.1, >= 4.1.1)
   redcarpet (~> 3.5, >= 3.5.1)
   retryable (~> 3.0, >= 3.0.5)
   sass-rails (~> 5.0)

--- a/app/admin/dashboard.rb
+++ b/app/admin/dashboard.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ActiveAdmin.register_page "Dashboard" do
   menu priority: 1, label: proc { I18n.t("active_admin.dashboard") }
 
@@ -28,5 +29,5 @@ ActiveAdmin.register_page "Dashboard" do
     #     end
     #   end
     # end
-  end
+  end # content
 end

--- a/app/admin/ranks.rb
+++ b/app/admin/ranks.rb
@@ -1,6 +1,9 @@
 ActiveAdmin.register Rank do
   actions :index, :show, :edit, :update, :new, :create
   permit_params :order, :abbr, :name, :grade, :image, :description, :remove_image
+  
+  filter :name_cont
+  filter :abbr_cont
 
   index do
     selectable_column

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,4 +7,14 @@ class Ability < ApplicationRecord
   def display_name
     abbr
   end
+  
+  private
+
+  def self.ransackable_attributes(_auth_object)
+    %w(id name abbr)
+  end
+  
+  def self.ransackable_associations(_auth_object)
+    %w(permissions)
+  end
 end

--- a/app/models/ait_qualification.rb
+++ b/app/models/ait_qualification.rb
@@ -11,4 +11,14 @@ class AITQualification < ApplicationRecord
                            uniqueness: {scope: :user, message: "User already has this AIT Standard"}
   validates :author, presence: true
   validates :date, presence: true, timeliness: {date: true}
+
+  private
+
+  def self.ransackable_attributes(_auth_object)
+    %w(id date)
+  end
+  
+  def self.ransackable_associations(_auth_object)
+    %w(user ait_standard author)
+  end
 end

--- a/app/models/ait_standard.rb
+++ b/app/models/ait_standard.rb
@@ -26,6 +26,10 @@ class AITStandard < ApplicationRecord
 
   private
 
+  def self.ransackable_attributes(_auth_object)
+    %w(id weapon game badge)
+  end
+
   def nil_or_na(value)
     value.nil? || value == "notapplicable"
   end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -34,4 +34,14 @@ class Assignment < ApplicationRecord
   def self.since(date)
     where("start_date >= ?", date)
   end
+  
+  private
+
+  def self.ransackable_attributes(_auth_object)
+    %w(id access_level start_date end_date)
+  end
+
+  def self.ransackable_associations(_auth_object)
+    %w(user unit position)
+  end
 end

--- a/app/models/award.rb
+++ b/app/models/award.rb
@@ -17,4 +17,10 @@ class Award < ApplicationRecord
   validates :order, numericality: {only_integer: true}, if: :present?
 
   scope :active, -> { where(active: true) }
+  
+  private
+
+  def self.ransackable_attributes(_auth_object)
+    %w(id code title game active)
+  end
 end

--- a/app/models/ban_log.rb
+++ b/app/models/ban_log.rb
@@ -15,4 +15,14 @@ class BanLog < ApplicationRecord
   validates :reason, length: {maximum: 1000}
 
   self.skip_time_zone_conversion_for_attributes = [:unbanned]
+
+  private
+  
+  def self.ransackable_attributes(_auth_object)
+    %w(id roid uid guid handle reason comments ip)
+  end
+  
+  def self.ransackable_associations(_auth_object)
+    %w(admin)
+  end
 end

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -8,4 +8,10 @@ class Country < ApplicationRecord
   def sym
     abbr.downcase.to_sym
   end
+  
+  private
+
+  def self.ransackable_attributes(_auth_object)
+    %w(id abbr name)
+  end
 end

--- a/app/models/demerit.rb
+++ b/app/models/demerit.rb
@@ -9,4 +9,14 @@ class Demerit < ApplicationRecord
   validates :user, presence: true
   validates :author, presence: true
   validates :reason, presence: true
+  
+  private
+  
+  def self.ransackable_attributes(_auth_object)
+    %w(id date reason)
+  end
+  
+  def self.ransackable_associations(_auth_object)
+    %w(user)
+  end
 end

--- a/app/models/discharge.rb
+++ b/app/models/discharge.rb
@@ -17,4 +17,14 @@ class Discharge < ApplicationRecord
   validates_date :date
   validates :type, presence: true
   validates :reason, presence: true
+  
+  private
+
+  def self.ransackable_attributes(_auth_object)
+    %w(id date type)
+  end
+
+  def self.ransackable_associations(_auth_object)
+    %w(user)
+  end
 end

--- a/app/models/enlistment.rb
+++ b/app/models/enlistment.rb
@@ -36,6 +36,14 @@ class Enlistment < ApplicationRecord
 
   private
 
+  def self.ransackable_attributes(_auth_object)
+    %w(id date game timezone status game timezone)
+  end
+  
+  def self.ransackable_associations(_auth_object)
+    %w(user liaison recruiter_user unit)
+  end
+
   def set_date
     self.date = Date.current
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -110,6 +110,14 @@ class Event < ApplicationRecord
 
   private
 
+  def self.ransackable_attributes(_auth_object)
+    %w(id datetime type title mandatory)
+  end
+
+  def self.ransackable_associations(_auth_object)
+    %w(unit server reporter)
+  end
+
   def update_report_dates
     self.report_posting_date ||= Time.current
     self.report_edit_date = Time.current

--- a/app/models/extended_loa.rb
+++ b/app/models/extended_loa.rb
@@ -29,6 +29,14 @@ class ExtendedLOA < ApplicationRecord
 
   private
 
+  def self.ransackable_attributes(_auth_object)
+    %w(id start end reason)
+  end
+  
+  def self.ransackable_associations(_auth_object)
+    %w(user)
+  end
+
   def set_posting_date
     self.posting_date = Time.zone.now
   end

--- a/app/models/finance_record.rb
+++ b/app/models/finance_record.rb
@@ -36,6 +36,14 @@ class FinanceRecord < ApplicationRecord
 
   private
 
+  def self.ransackable_attributes(_auth_object)
+    %w(id date vendor amount_received amount_paid fee)
+  end
+
+  def self.ransackable_associations(_auth_object)
+    %w(user)
+  end
+
   def received_or_paid
     unless amount_received.blank? ^ amount_paid.blank?
       errors.add(:base, "Specify an amount received or paid, not both")

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -30,6 +30,14 @@ class Note < ApplicationRecord
 
   private
 
+  def self.ransackable_attributes(_auth_object)
+    %w(id date_add access subject)
+  end
+  
+  def self.ransackable_associations(_auth_object)
+    %w(user)
+  end
+
   def set_date_created
     self.date_add = Date.current
   end

--- a/app/models/pass.rb
+++ b/app/models/pass.rb
@@ -24,19 +24,19 @@ class Pass < ApplicationRecord
   scope :active, -> { where("start_date <= ? AND end_date >= ?", Date.current, Date.current) }
 
   def self.ransackable_attributes(_auth_object)
-    %w[type start_date end_date]
+    %w(id type start_date end_date)
   end
 
   def self.ransortable_attributes(_auth_object)
-    %w[start_date end_date type]
+    %w(start_date end_date type)
   end
 
   def self.ransackable_associations(_auth_object)
-    %w[user]
+    %w(user)
   end
 
   def self.ransackable_scopes(_auth_object)
-    %i[active]
+    %i(active)
   end
 
   def set_add_date

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -8,4 +8,14 @@ class Permission < ApplicationRecord
 
   validates_presence_of :unit, :ability, :access_level
   validates :ability, uniqueness: {scope: [:unit, :access_level], message: "Permission combination already exists"}
+  
+  private
+
+  def self.ransackable_attributes(_auth_object)
+    %w(id access_level)
+  end
+
+  def self.ransackable_associations(_auth_object)
+    %w(unit ability)
+  end
 end

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -19,4 +19,10 @@ class Position < ApplicationRecord
 
   scope :active, -> { where(active: true) }
   scope :for_dropdown, -> { active.order(:name) }
+  
+  private
+
+  def self.ransackable_attributes(_auth_object)
+    %w(id name active access_level AIT)
+  end
 end

--- a/app/models/promotion.rb
+++ b/app/models/promotion.rb
@@ -13,4 +13,14 @@ class Promotion < ApplicationRecord
   def demotion?
     old_rank.present? && old_rank.order > new_rank.order
   end
+  
+  private
+  
+  def self.ransackable_attributes(_auth_object)
+    %w(id date)
+  end
+  
+  def self.ransackable_associations(_auth_object)
+    %w(user old_rank new_rank)
+  end
 end

--- a/app/models/rank.rb
+++ b/app/models/rank.rb
@@ -19,4 +19,10 @@ class Rank < ApplicationRecord
   def officer?
     grade&.starts_with? "O-"
   end
+  
+  private
+
+  def self.ransackable_attributes(_auth_object)
+    %w(id name abbr grade)
+  end
 end

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -11,4 +11,10 @@ class Server < ApplicationRecord
   validates :address, presence: true
   validates :port, presence: true, numericality: {only_integer: true}
   validates :active, inclusion: [true, false]
+  
+  private
+
+  def self.ransackable_attributes(_auth_object)
+    %w(id name abbr game)
+  end
 end

--- a/app/models/special_forum_role.rb
+++ b/app/models/special_forum_role.rb
@@ -18,4 +18,10 @@ class SpecialForumRole < ApplicationRecord
   validates :role_id, numericality: {only_integer: true}
 
   attr_accessor :discourse_role_id, :vanilla_role_id
+  
+  private
+
+  def self.ransackable_attributes(_auth_object)
+    %w(id special_attribute forum_id role_id)
+  end
 end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -63,6 +63,14 @@ class Unit < ApplicationRecord
 
   private
 
+  def self.ransackable_attributes(_auth_object)
+    %w(id name abbr game timezone active ancestry classification)
+  end
+  
+  def self.ransackable_associations(_auth_object)
+    %w(ancestors)
+  end
+
   def update_path_from_ancestry
     # path is still used by v2, and is identical to ancestry, plus surrounding slashes
     self.path = "/#{ancestry}/" if ancestry_changed?

--- a/app/models/unit_forum_role.rb
+++ b/app/models/unit_forum_role.rb
@@ -14,4 +14,14 @@ class UnitForumRole < ApplicationRecord
   validates :role_id, numericality: {only_integer: true}
 
   attr_accessor :discourse_role_id, :vanilla_role_id
+  
+  private
+
+  def self.ransackable_attributes(_auth_object)
+    %w(id access_level forum_id role_id)
+  end
+
+  def self.ransackable_associations(_auth_object)
+    %w(unit)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -200,6 +200,14 @@ class User < ApplicationRecord
 
   private
 
+  def self.ransackable_attributes(_auth_object)
+    %w(id last_name first_name steam_id forum_member_id)
+  end
+  
+  def self.ransackable_associations(_auth_object)
+    %w(rank country)
+  end
+
   def slug_candidates
     [
       [:name_prefix, :last_name],

--- a/app/models/user_award.rb
+++ b/app/models/user_award.rb
@@ -7,4 +7,14 @@ class UserAward < ApplicationRecord
 
   validates :date, presence: true
   validates_date :date
+  
+  private
+
+  def self.ransackable_attributes(_auth_object)
+    %w(id date)
+  end
+
+  def self.ransackable_associations(_auth_object)
+    %w(user award)
+  end
 end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -20,6 +20,23 @@ ActiveAdmin.setup do |config|
   #
   # config.site_title_image = "logo.png"
 
+  # == Load Paths
+  #
+  # By default Active Admin files go inside app/admin/.
+  # You can change this directory.
+  #
+  # eg:
+  #   config.load_paths = [File.join(Rails.root, 'app', 'ui')]
+  #
+  # Or, you can also load more directories.
+  # Useful when setting namespaces with users that are not your main AdminUser entity.
+  #
+  # eg:
+  #   config.load_paths = [
+  #     File.join(Rails.root, 'app', 'admin'),
+  #     File.join(Rails.root, 'app', 'cashier')
+  #   ]
+
   # == Default Namespace
   #
   # Set the default namespace each administration resource
@@ -70,6 +87,11 @@ ActiveAdmin.setup do |config|
   # the name of default policy class. This policy will be used in every
   # case when Pundit is unable to find suitable policy.
   config.pundit_default_policy = "ApplicationPolicy"
+
+  # If you wish to maintain a separate set of Pundit policies for admin
+  # resources, you may set a namespace here that Pundit will search
+  # within when looking for a resource's policy.
+  # config.pundit_policy_namespace = :admin
 
   # You can customize your CanCan Ability class name here.
   # config.cancan_ability_class = "Ability"
@@ -149,11 +171,21 @@ ActiveAdmin.setup do |config|
   #
   # config.before_action :do_something_awesome
 
+  # == Attribute Filters
+  #
+  # You can exclude possibly sensitive model attributes from being displayed,
+  # added to forms, or exported by default by ActiveAdmin
+  #
+  config.filter_attributes = [:encrypted_password, :password, :password_confirmation]
+
   # == Localize Date/Time Format
   #
   # Set the localize format to display dates and times.
   # To understand how to localize your app with I18n, read more at
-  # https://github.com/svenfuchs/i18n/blob/master/lib%2Fi18n%2Fbackend%2Fbase.rb#L52
+  # https://guides.rubyonrails.org/i18n.html
+  #
+  # You can run `bin/rails runner 'puts I18n.t("date.formats")'` to see the
+  # available formats in your application.
   #
   config.localize_format = :long
 
@@ -274,11 +306,31 @@ ActiveAdmin.setup do |config|
   # config.filters = true
   #
   # By default the filters include associations in a select, which means
-  # that every record will be loaded for each association.
+  # that every record will be loaded for each association (up
+  # to the value of config.maximum_association_filter_arity).
   # You can enabled or disable the inclusion
   # of those filters by default here.
   #
   # config.include_default_association_filters = true
+
+  # config.maximum_association_filter_arity = 256 # default value of :unlimited will change to 256 in a future version
+  # config.filter_columns_for_large_association = [
+  #    :display_name,
+  #    :full_name,
+  #    :name,
+  #    :username,
+  #    :login,
+  #    :title,
+  #    :email,
+  #  ]
+  # config.filter_method_for_large_association = '_start'
+
+  # == Head
+  #
+  # You can add your own content to the site head like analytics. Make sure
+  # you only pass content you trust.
+  #
+  # config.head = ''.html_safe
 
   # == Footer
   #

--- a/config/initializers/activeadmin_addons.rb
+++ b/config/initializers/activeadmin_addons.rb
@@ -1,0 +1,12 @@
+ActiveadminAddons.setup do |config|
+  # Change to "default" if you want to use ActiveAdmin's default select control.
+  # config.default_select = "select2"
+
+  # Set default options for DateTimePickerInput. The options you can provide are the same as in
+  # xdan's datetimepicker library (https://github.com/xdan/datetimepicker/tree/2.5.4). Yo need to
+  # pass a ruby hash, avoid camelCase keys. For example: use min_date instead of minDate key.
+  # config.datetime_picker_default_options = {}
+
+  # Set DateTimePickerInput input format. This if for backend (Ruby)
+  # config.datetime_picker_input_format = "%Y-%m-%d %H:%M"
+end


### PR DESCRIPTION
Upgrade activeadmin to v3.1.0, ransack to v4.1.1, and activeadmin_addons to v1.10.1

Also declares ransackable_attributes and ransackable_associations in every model activeadmin uses