### PR TITLE
Use state with DiscourseService and VanillaService to improve performance

### DIFF
--- a/app/manage/special_forum_roles.rb
+++ b/app/manage/special_forum_roles.rb
@@ -64,12 +64,14 @@ ActiveAdmin.register SpecialForumRole do
       @roles ||= begin
         discourse = begin
           DiscourseService.new.roles
-        rescue
+        rescue Faraday::Error => err
+          Appsignal.set_error(err)
           {}
         end
         vanilla = begin
           VanillaService.new.roles
-        rescue
+        rescue Faraday::Error => err
+          Appsignal.set_error(err)
           {}
         end
         {discourse: discourse, vanilla: vanilla}

--- a/app/manage/special_forum_roles.rb
+++ b/app/manage/special_forum_roles.rb
@@ -63,7 +63,7 @@ ActiveAdmin.register SpecialForumRole do
     def roles
       @roles ||= begin
         discourse = begin
-          DiscourseService.new.get_roles
+          DiscourseService.new.roles
         rescue
           {}
         end

--- a/app/manage/special_forum_roles.rb
+++ b/app/manage/special_forum_roles.rb
@@ -68,7 +68,7 @@ ActiveAdmin.register SpecialForumRole do
           {}
         end
         vanilla = begin
-          VanillaService.new.get_roles
+          VanillaService.new.roles
         rescue
           {}
         end

--- a/app/manage/unit_forum_roles.rb
+++ b/app/manage/unit_forum_roles.rb
@@ -69,7 +69,7 @@ ActiveAdmin.register UnitForumRole do
     def roles
       @roles ||= begin
         discourse = begin
-          DiscourseService.new.get_roles
+          DiscourseService.new.roles
         rescue
           {}
         end

--- a/app/manage/unit_forum_roles.rb
+++ b/app/manage/unit_forum_roles.rb
@@ -74,7 +74,7 @@ ActiveAdmin.register UnitForumRole do
           {}
         end
         vanilla = begin
-          VanillaService.new.get_roles
+          VanillaService.new.roles
         rescue
           {}
         end

--- a/app/manage/unit_forum_roles.rb
+++ b/app/manage/unit_forum_roles.rb
@@ -70,12 +70,14 @@ ActiveAdmin.register UnitForumRole do
       @roles ||= begin
         discourse = begin
           DiscourseService.new.roles
-        rescue
+        rescue Faraday::Error => err
+          Appsignal.set_error(err)
           {}
         end
         vanilla = begin
           VanillaService.new.roles
-        rescue
+        rescue Faraday::Error => err
+          Appsignal.set_error(err)
           {}
         end
         {discourse: discourse, vanilla: vanilla}

--- a/app/models/enlistment.rb
+++ b/app/models/enlistment.rb
@@ -39,20 +39,7 @@ class Enlistment < ApplicationRecord
 
   before_create :set_date
 
-  def linked_forum_users
-    @linked_forum_users ||= begin
-      linked_forum_users = []
-      if user&.forum_member_id
-        discourse_users = DiscourseService.new.get_linked_users(user.forum_member_id)
-        linked_forum_users.concat(discourse_users)
-      end
-      if user&.vanilla_forum_member_id
-        vanilla_users = VanillaService.new.get_linked_users(user.vanilla_forum_member_id)
-        linked_forum_users.concat(vanilla_users)
-      end
-      linked_forum_users
-    end
-  end
+  delegate :linked_forum_users, to: :user
 
   def linked_ban_logs
     steam_ids = [steam_id, user.steam_id].uniq # enlistment steam id may differ

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -195,12 +195,12 @@ class User < ApplicationRecord
   end
 
   def vanilla_forum_member_username
-    @vanilla_forum_member_username ||= VanillaService.new.get_username(vanilla_forum_member_id) if vanilla_forum_member_id.present?
+    @vanilla_forum_member_username ||= vanilla_service.user.username if vanilla_forum_member_id.present?
   end
 
   def update_forum_display_name
     discourse_service.user.update_display_name(short_name) if forum_member_id.present?
-    VanillaService.new.update_user_display_name(vanilla_forum_member_id, short_name) if vanilla_forum_member_id.present?
+    vanilla_service.user.update_display_name(short_name) if vanilla_forum_member_id.present?
   end
 
   def update_forum_roles
@@ -211,7 +211,7 @@ class User < ApplicationRecord
 
     if vanilla_forum_member_id.present?
       expected_roles = forum_role_ids(:vanilla)
-      VanillaService.new.update_user_roles(vanilla_forum_member_id, expected_roles)
+      vanilla_service.user.update_roles(expected_roles)
     end
   end
 
@@ -223,7 +223,7 @@ class User < ApplicationRecord
         linked_forum_users.concat(discourse_users)
       end
       if vanilla_forum_member_id
-        vanilla_users = VanillaService.new.get_linked_users(vanilla_forum_member_id)
+        vanilla_users = vanilla_service.user.linked_users
         linked_forum_users.concat(vanilla_users)
       end
       linked_forum_users
@@ -265,6 +265,10 @@ class User < ApplicationRecord
 
   def discourse_service
     @discourse_service ||= DiscourseService.new(forum_member_id)
+  end
+
+  def vanilla_service
+    @vanilla_service ||= VanillaService.new(vanilla_forum_member_id)
   end
 
   def slug_candidates

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -187,11 +187,11 @@ class User < ApplicationRecord
   end
 
   def forum_member_username
-    @forum_member_username ||= DiscourseService.new.get_username(forum_member_id) if forum_member_id.present?
+    @forum_member_username ||= discourse_service.user.username if forum_member_id.present?
   end
 
   def forum_member_email
-    @forum_member_email ||= DiscourseService.new.get_email(forum_member_id) if forum_member_id.present?
+    @forum_member_email ||= discourse_service.user.email if forum_member_id.present?
   end
 
   def vanilla_forum_member_username
@@ -199,19 +199,34 @@ class User < ApplicationRecord
   end
 
   def update_forum_display_name
-    DiscourseService.new.update_user_display_name(forum_member_id, short_name) if forum_member_id.present?
+    discourse_service.user.update_display_name(short_name) if forum_member_id.present?
     VanillaService.new.update_user_display_name(vanilla_forum_member_id, short_name) if vanilla_forum_member_id.present?
   end
 
   def update_forum_roles
     if forum_member_id.present?
       expected_roles = forum_role_ids(:discourse)
-      DiscourseService.new.update_user_roles(forum_member_id, expected_roles)
+      discourse_service.user.update_roles(expected_roles)
     end
 
     if vanilla_forum_member_id.present?
       expected_roles = forum_role_ids(:vanilla)
       VanillaService.new.update_user_roles(vanilla_forum_member_id, expected_roles)
+    end
+  end
+
+  def linked_forum_users
+    @linked_forum_users ||= begin
+      linked_forum_users = []
+      if forum_member_id
+        discourse_users = discourse_service.user.linked_users
+        linked_forum_users.concat(discourse_users)
+      end
+      if vanilla_forum_member_id
+        vanilla_users = VanillaService.new.get_linked_users(vanilla_forum_member_id)
+        linked_forum_users.concat(vanilla_users)
+      end
+      linked_forum_users
     end
   end
 
@@ -247,6 +262,10 @@ class User < ApplicationRecord
   end
 
   private
+
+  def discourse_service
+    @discourse_service ||= DiscourseService.new(forum_member_id)
+  end
 
   def slug_candidates
     [

--- a/app/services/vanilla_service.rb
+++ b/app/services/vanilla_service.rb
@@ -16,9 +16,9 @@ class VanillaService
   end
 
   def roles
-    response = @conn.get("/roles")
+    response = @conn.get("roles")
 
-    response.each_with_object({}) do |role, accum|
+    response.body.each_with_object({}) do |role, accum|
       accum[role["roleID"]] = role["name"]
     end
   end

--- a/app/services/vanilla_service.rb
+++ b/app/services/vanilla_service.rb
@@ -1,7 +1,7 @@
 class VanillaService
-  class NoLinkedAccountError < StandardError; end
+  attr_reader :user
 
-  def initialize
+  def initialize(forum_member_id = nil)
     config = Rails.configuration.endpoints[:vanilla]
     url = "#{config[:base_url][:internal]}/api/v2"
     @conn = Faraday.new(url) do |conn|
@@ -11,15 +11,11 @@ class VanillaService
       conn.response :json, content_type: /\bjson$/
       conn.response :logger, nil, {headers: false, bodies: true} unless Rails.env.test?
     end
+
+    @user = VanillaUser.new(@conn, forum_member_id) if forum_member_id
   end
 
-  def get_username(forum_member_id)
-    path = "users/#{forum_member_id}"
-    response = @conn.get(path)
-    response.body["name"]
-  end
-
-  def get_roles
+  def roles
     response = @conn.get("/roles")
 
     response.each_with_object({}) do |role, accum|
@@ -27,41 +23,58 @@ class VanillaService
     end
   end
 
-  def update_user_display_name(forum_member_id, display_name)
-    sanitized_name = display_name.delete("/")
-    path = "users/#{forum_member_id}"
-    body = {name: sanitized_name}
-    @conn.patch(path, body)
-  end
+  class VanillaUser
+    def initialize(conn, forum_member_id)
+      @conn = conn
+      @forum_member_id = forum_member_id
+    end
 
-  def update_user_roles(forum_member_id, expected_roles)
-    path = "users/#{forum_member_id}"
-    body = {roleID: expected_roles}
-    @conn.patch(path, body)
-  end
+    def username
+      user_data["name"]
+    end
 
-  def get_linked_users(forum_member_id)
-    path = "users/#{forum_member_id}"
-    response = @conn.get(path)
-    raise Faraday::Error.new("response missing IP addresses") unless response.body.key?("ips")
+    def update_display_name(display_name)
+      sanitized_name = display_name.delete("/")
+      path = "users/#{@forum_member_id}"
+      body = {name: sanitized_name}
+      @conn.patch(path, body)
+    end
 
-    rows = response.body["ips"].map { |row| row.deep_transform_keys(&:underscore) }
-    key_ips_by_user(rows)
-  end
+    def update_roles(expected_roles)
+      path = "users/#{@forum_member_id}"
+      body = {roleID: expected_roles}
+      @conn.patch(path, body)
+    end
 
-  private
+    def linked_users
+      raise Faraday::Error.new("response missing IP addresses - vanilla plugin may be disabled") unless user_data.has_key?("ips")
 
-  # Invert structure to be keyed by user
-  def key_ips_by_user(rows)
-    users = rows.each_with_object({}) do |row, memo|
-      row["other_users"].each do |other_user|
-        name = other_user["name"]
-        user_id = other_user["user_id"]
-        memo[name] ||= {username: name, user_id: user_id, ips: [],
-                        forum: :vanilla}
-        memo[name][:ips] << row["ip"]
+      rows = user_data["ips"].map { |row| row.deep_transform_keys(&:underscore) }
+      key_ips_by_user(rows)
+    end
+
+    private
+
+    def user_data
+      @user_data ||= begin
+        path = "users/#{@forum_member_id}"
+        response = @conn.get(path)
+        response.body
       end
     end
-    users.values
+
+    # Invert structure to be keyed by user
+    def key_ips_by_user(rows)
+      users = rows.each_with_object({}) do |row, memo|
+        row["other_users"].each do |other_user|
+          name = other_user["name"]
+          user_id = other_user["user_id"]
+          memo[name] ||= {username: name, user_id: user_id, ips: [],
+                          forum: :vanilla}
+          memo[name][:ips] << row["ip"]
+        end
+      end
+      users.values
+    end
   end
 end

--- a/test/services/discourse_service_test.rb
+++ b/test/services/discourse_service_test.rb
@@ -17,7 +17,7 @@ class DiscourseServiceTest < ActiveSupport::TestCase
     stub_update = stub_request(:put, %r{/u/#{username}})
       .with(body: request_body.to_json)
 
-    DiscourseService.new.update_user_display_name(forum_member_id, user.short_name)
+    DiscourseService.new(forum_member_id).user.update_display_name(user.short_name)
 
     assert_requested(stub_update)
   end
@@ -31,7 +31,7 @@ class DiscourseServiceTest < ActiveSupport::TestCase
     stub_request(:put, %r{/u/#{username}}).to_return(status: [500, "Internal Server Error"])
 
     assert_raises Faraday::ServerError do
-      DiscourseService.new.update_user_display_name(forum_member_id, user.short_name)
+      DiscourseService.new(forum_member_id).user.update_display_name(user.short_name)
     end
   end
 

--- a/test/services/vanilla_service_test.rb
+++ b/test/services/vanilla_service_test.rb
@@ -9,12 +9,12 @@ class VanillaServiceTest < ActiveSupport::TestCase
     stub_update = stub_request(:patch, %r{/users/#{vanilla_forum_member_id}})
       .with(body: request_body.to_json)
 
-    VanillaService.new.update_user_display_name(vanilla_forum_member_id, user.short_name)
+    VanillaService.new(vanilla_forum_member_id).user.update_display_name(user.short_name)
 
     assert_requested(stub_update)
   end
 
-  test "update_user_roles sends expected roles" do
+  test "update_roles sends expected roles" do
     vanilla_forum_member_id = 1
     user = create(:user, vanilla_forum_member_id: vanilla_forum_member_id, forum_member_id: nil)
     unit = create(:unit)
@@ -31,7 +31,7 @@ class VanillaServiceTest < ActiveSupport::TestCase
     assert_requested(stub)
   end
 
-  test "get_linked_users groups ips by user" do
+  test "linked_users groups ips by user" do
     vanilla_user_id = 1
 
     response_body = {ips: [
@@ -47,7 +47,7 @@ class VanillaServiceTest < ActiveSupport::TestCase
     stub_request(:get, %r{/users/#{vanilla_user_id}})
       .to_return(body: response_body.to_json, headers: {"Content-Type" => "application/json"})
 
-    linked_users = VanillaService.new.get_linked_users(vanilla_user_id)
+    linked_users = VanillaService.new(vanilla_user_id).user.linked_users
 
     assert_equal 2, linked_users.size
 


### PR DESCRIPTION
The show enlistment pages should load quicker with this change because duplicate requests to the discourse and vanilla APIs are consolidated (reused).