### PR TITLE
Training platoon graduation

### DIFF
--- a/app/manage/events.rb
+++ b/app/manage/events.rb
@@ -95,6 +95,6 @@ ActiveAdmin.register Event do
     link_to "View on site", event_path(event)
   end
 
-  config.sort_order = "datetime_desc"
+  config.sort_order = "starts_at_desc"
   config.create_another = true
 end

--- a/app/manage/training_platoons.rb
+++ b/app/manage/training_platoons.rb
@@ -1,16 +1,32 @@
-ActiveAdmin.register Unit, as: "Training Platoon" do
+ActiveAdmin.register TrainingPlatoon do
   controller do
     def scoped_collection
-      end_of_association_chain.training_platoons
+      # the usual includes config doesn't seem to apply to show pages
+      # so we're doing it here instead
+      super.includes(:events, enlistments: [user: :rank])
     end
 
     def find_resource
       scoped_collection.friendly.find(params[:id])
     end
+
+    private
+
+    def graduation_params
+      params.require(:forms_graduation).permit(
+        :rank_id,
+        :position_id,
+        :topic_id,
+        award_ids: [],
+        cadets_attributes: [
+          :id,
+          :unit_id
+        ]
+      )
+    end
   end
 
-  actions :index
-  includes :events, :assignments
+  actions :index, :show
 
   scope :active, default: true
   scope :all, default: true
@@ -29,15 +45,69 @@ ActiveAdmin.register Unit, as: "Training Platoon" do
       Unit.timezones[tp.timezone]
     end
     column :dates do |tp|
-      span timestamp_tag(tp.events.last.starts_at_local, "%F")
-      span " - "
-      span timestamp_tag(tp.events.first.starts_at_local, "%F")
+      if tp.events.any?
+        span timestamp_tag(tp.events.last.starts_at_local, "%F")
+        span " - "
+        span timestamp_tag(tp.events.first.starts_at_local, "%F")
+      end
     end
     column :recruits do |tp|
-      tp.assignments.size
+      tp.enlistments.count(&:accepted?)
     end
-    # actions defaults: false do |tp|
-    #   item "View", manage_training_platoon_path(tp)
-    # end
+    actions defaults: false do |tp|
+      item "View", manage_training_platoon_path(tp)
+    end
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :name
+      row :game do |tp|
+        Unit.games[tp.game]
+      end
+      row :timezone do |tp|
+        Unit.timezones[tp.timezone]
+      end
+    end
+
+    panel "Recruits" do
+      table_for training_platoon.enlistments do
+        column :user
+        tag_column :status
+        column "" do |enlistment|
+          link_to "View Enlistment", manage_enlistment_path(enlistment)
+        end
+      end
+    end
+  end
+
+  action_item :edit_unit, only: :show,
+    if: proc { authorized?(:edit, training_platoon) } do
+    link_to "Edit Unit", manage_unit_path(training_platoon)
+  end
+
+  action_item :graduate, only: :show,
+    if: proc { authorized?(:graduate, training_platoon) } do
+    link_to "Graduate", graduate_manage_training_platoon_path(training_platoon)
+  end
+
+  member_action :graduate, method: [:get, :post] do
+    @squads = Unit.ordered_squads
+    @awards = Award.active.order(:title)
+    @ranks = Rank.all
+    @positions = Position.active
+
+    if request.post?
+      @graduation = Forms::Graduation.new(unit: resource, **graduation_params)
+      if @graduation.save
+        redirect_to resource_path, notice: "Graduation processed"
+      else
+        render :graduate
+      end
+    else
+      @graduation = Forms::Graduation.new(unit: resource, cadets: resource.cadets)
+      render :graduate
+    end
   end
 end

--- a/app/manage/training_platoons.rb
+++ b/app/manage/training_platoons.rb
@@ -1,0 +1,43 @@
+ActiveAdmin.register Unit, as: "Training Platoon" do
+  controller do
+    def scoped_collection
+      end_of_association_chain.training_platoons
+    end
+
+    def find_resource
+      scoped_collection.friendly.find(params[:id])
+    end
+  end
+
+  actions :index
+  includes :events, :assignments
+
+  scope :active, default: true
+  scope :all, default: true
+
+  filter :abbr
+  filter :game, as: :select, collection: -> { Unit.games }
+  filter :timezone, as: :select, collection: -> { Unit.timezones }
+
+  index do
+    column :abbr
+    column :active
+    column :game do |tp|
+      Unit.games[tp.game]
+    end
+    column :timezone do |tp|
+      Unit.timezones[tp.timezone]
+    end
+    column :dates do |tp|
+      span timestamp_tag(tp.events.last.starts_at_local, "%F")
+      span " - "
+      span timestamp_tag(tp.events.first.starts_at_local, "%F")
+    end
+    column :recruits do |tp|
+      tp.assignments.size
+    end
+    # actions defaults: false do |tp|
+    #   item "View", manage_training_platoon_path(tp)
+    # end
+  end
+end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,6 +1,6 @@
 class Assignment < ApplicationRecord
   audited
-  belongs_to :unit
+  belongs_to :unit, inverse_of: :assignments
   belongs_to :user, foreign_key: "member_id", inverse_of: :assignments
   belongs_to :position
 

--- a/app/models/cadet.rb
+++ b/app/models/cadet.rb
@@ -1,0 +1,6 @@
+class Cadet < User
+  attr_accessor :unit_id
+
+  # Idea: use on: :graduation to move to User model without breaking saving
+  validates_associated :assignments, :promotions, :user_awards
+end

--- a/app/models/forms/graduation.rb
+++ b/app/models/forms/graduation.rb
@@ -1,0 +1,95 @@
+class Forms::Graduation
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  attr_accessor :unit
+  attr_accessor :cadets
+  attr_accessor :award_ids
+  attribute :rank_id, :integer
+  attribute :position_id, :integer
+  attribute :topic_id, :integer
+
+  validates :unit, presence: true
+  validates :award_ids, presence: true
+  validates :rank_id, presence: true
+  validates :position_id, presence: true
+  validates :cadets, presence: true
+  validates :topic_id, presence: true
+
+  # "forms_graduation"=>{
+  #   "cadets_attributes"=>{
+  #     "0"=>{"unit_id"=>"28", "id"=>"92295"},
+  #     "1"=>{"unit_id"=>"29", "id"=>"92301"},
+  #     "2"=>{"unit_id"=>"1246", "id"=>"92290"}
+  #   },
+  #   "award_ids"=>["", "27", "109"],
+  #   "rank_id"=>"2",
+  #   "position_id"=>"1",
+  #   "topic_id"=>"123"
+  # }
+  def cadets_attributes=(attributes)
+    attributes_collection = attributes.values.filter { |a| a.key?("id") }
+    @assignments = attributes_collection.each_with_object({}) do |a, memo|
+      memo[a["id"].to_i] = a["unit_id"].to_i
+    end
+    user_ids = @assignments.keys
+    @cadets = user_ids.empty? ? [] : Cadet.where(id: user_ids)
+  end
+
+  def save
+    return false unless valid?
+
+    cadets.each(&method(:verify_eligibility!))
+
+    ActiveRecord::Base.transaction do
+      cadets.each { |cadet| graduate_user!(cadet, @assignments[cadet.id]) }
+
+      unit.end_assignments
+      unit.update!(active: false)
+    end
+
+    cadets.each(&method(:queue_background_jobs)) # unless txn fails?
+  rescue ActiveRecord::RecordInvalid
+    false
+  end
+
+  private
+
+  def verify_eligibility!(user)
+    if user.member? || !user.assigned_to_unit?(unit) || !unit.enlistments.accepted.exists?(user: user)
+      raise IneligibleCadet.new(user: user)
+    end
+  end
+
+  def graduate_user!(user, assignment_unit_id)
+    user.assignments.build(unit_id: assignment_unit_id, position_id: position_id,
+      start_date: Date.current)
+
+    user.promotions.build(new_rank_id: rank_id, old_rank_id: user.rank.id,
+      date: Date.current, forum_id: :discourse, topic_id: topic_id)
+    user.rank_id = rank_id
+
+    award_ids.each do |award_id|
+      user.user_awards.build(award_id: award_id, date: Date.current,
+        forum_id: :discourse, topic_id: topic_id)
+    end
+
+    user.save!
+  end
+
+  def queue_background_jobs(user)
+    user.delay.update_forum_display_name
+    user.delay.update_forum_roles
+    user.delay.update_coat
+  end
+
+  class IneligibleCadet < StandardError
+    attr_reader :user
+
+    def initialize(message = nil, user: nil)
+      @user = user
+      message ||= "Cadet is ineligible for graduation: #{user}"
+      super(message)
+    end
+  end
+end

--- a/app/models/training_platoon.rb
+++ b/app/models/training_platoon.rb
@@ -1,0 +1,6 @@
+class TrainingPlatoon < Unit
+  default_scope { training_platoons }
+
+  has_many :_accepted_enlistments, -> { accepted }, class_name: "Enlistment", foreign_key: "unit_id"
+  has_many :cadets, through: :_accepted_enlistments, class_name: "Cadet", source: :user
+end

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -26,7 +26,7 @@ class Unit < ApplicationRecord
   }
   scope :with_event_range, -> {
     # Used by Process Enlistment action to show date range of training platoons
-    select("units.*, (SELECT CONCAT( DATE_FORMAT(MIN(datetime),'%d %b %Y'),' - ', DATE_FORMAT(MAX(datetime),'%d %b %Y')) FROM events WHERE events.unit_id = `units`.id) AS event_range")
+    select("units.*, (SELECT CONCAT( DATE_FORMAT(MIN(starts_at),'%d %b %Y'),' - ', DATE_FORMAT(MAX(starts_at),'%d %b %Y')) FROM events WHERE events.unit_id = `units`.id) AS event_range")
   }
 
   nilify_blanks

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -10,6 +10,7 @@ class Unit < ApplicationRecord
   has_many :permissions
   has_many :unit_forum_roles
   has_many :events, -> { order(starts_at: :desc) }, inverse_of: "unit"
+  has_many :enlistments
 
   enum game: {dh: "DH", rs: "RS", arma3: "Arma 3", rs2: "RS2", squad: "Squad"}
   enum timezone: {est: "EST", gmt: "GMT", pst: "PST"}

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -9,7 +9,7 @@ class Unit < ApplicationRecord
   has_many :users, through: :assignments
   has_many :permissions
   has_many :unit_forum_roles
-  has_many :events, inverse_of: "unit"
+  has_many :events, -> { order(starts_at: :desc) }, inverse_of: "unit"
 
   enum game: {dh: "DH", rs: "RS", arma3: "Arma 3", rs2: "RS2", squad: "Squad"}
   enum timezone: {est: "EST", gmt: "GMT", pst: "PST"}

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -29,6 +29,13 @@ class Unit < ApplicationRecord
     # Used by Process Enlistment action to show date range of training platoons
     select("units.*, (SELECT CONCAT( DATE_FORMAT(MIN(starts_at),'%d %b %Y'),' - ', DATE_FORMAT(MAX(starts_at),'%d %b %Y')) FROM events WHERE events.unit_id = `units`.id) AS event_range")
   }
+  scope :ordered_squads, -> {
+    active
+      .combat
+      .order(:ancestry, :order, :name)
+      .ransack({name_i_cont: "Squad"})
+      .result(distinct: true)
+  }
 
   nilify_blanks
   validates :name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -171,6 +171,10 @@ class User < ApplicationRecord
     enlistments.pending.any?
   end
 
+  def assigned_to_unit?(unit)
+    active_assignments.exists?(unit: unit)
+  end
+
   def assigned_to_subtree?(unit)
     active_assignment_unit_path_ids.include? unit.id
   end

--- a/app/policies/training_platoon_policy.rb
+++ b/app/policies/training_platoon_policy.rb
@@ -1,0 +1,13 @@
+class TrainingPlatoonPolicy < ApplicationPolicy
+  def index?
+    user&.has_permission?("admin")
+  end
+
+  def show?
+    user&.has_permission?("admin")
+  end
+
+  def graduate?
+    user&.has_permission?("admin")
+  end
+end

--- a/app/views/manage/training_platoons/graduate.html.erb
+++ b/app/views/manage/training_platoons/graduate.html.erb
@@ -1,0 +1,35 @@
+<%= simple_form_for @graduation, url: graduate_manage_training_platoon_path(resource) do |f| %>
+  <%= f.error_notification %>
+  
+  <fieldset class="inputs">
+    <legend><span>Assignments</span></legend>
+    <ol>
+      <%= f.simple_fields_for :cadets do |c| %>
+        <%= c.input :unit_id, label: link_to(c.object, manage_user_path(c.object)),
+          collection: @squads, wrapper_tag: "li", label_method: :abbr %>
+      <% end %>
+    </ol>
+  </fieldset>
+
+  <fieldset class="inputs">
+    <legend><span>Apply to all users</span></legend>
+    <ol>
+      <%= f.input :award_ids, label: "Awards", collection: @awards,
+        as: :select, multiple: true, wrapper_tag: "li", include_blank: false %>
+      <%= f.input :rank_id, collection: @ranks,
+        wrapper_tag: "li" %>
+      <%= f.input :position_id, collection: @positions,
+        wrapper_tag: "li" %>
+      <%= f.input :topic_id, label: "Topic ID", wrapper_tag: "li" %>
+    </ol>
+  </fieldset>
+  
+  <fieldset class="actions">
+    <ol>
+      <li><%= f.button :submit, "Process Graduation" %></li>
+      <li class="cancel">
+        <%= link_to "Cancel", manage_training_platoon_path(resource) %>
+      </li>
+    </ol>
+  </fieldset>
+<% end %>

--- a/test/manage/manage_training_platoons_controller_test.rb
+++ b/test/manage/manage_training_platoons_controller_test.rb
@@ -1,0 +1,134 @@
+require "test_helper"
+
+class Mange::TrainingPlatoonsControllerTest < ActionDispatch::IntegrationTest
+  class Graduation < Manage::TrainingPlatoonsControllerTest
+    setup do
+      @tp = create(:unit, classification: :training)
+
+      recruiter = create(:user)
+      @squad = create(:unit, name: "First Squad", abbr: "S1")
+      create(:assignment, user: recruiter, unit: @squad)
+
+      @cadets = create_list(:user, 5, rank_abbr: "Rec.")
+      @cadets.each do |cadet|
+        create(:enlistment, status: :accepted, unit: @tp, user: cadet,
+          timezone: :pst, recruiter_user: recruiter)
+        create(:assignment, unit: @tp, user: cadet)
+      end
+
+      @unit = create(:unit)
+      create(:permission, abbr: "admin", unit: @unit)
+      @user = create(:user)
+      create(:assignment, user: @user, unit: @unit)
+
+      @awards = create_list(:award, 3)
+      @rank = create(:rank)
+      @position = create(:position, name: "Rifleman")
+
+      sign_in_as @user
+    end
+
+    test "lists users with accepted enlistments" do
+      get graduate_manage_training_platoon_path(@tp)
+
+      @cadets.each do |cadet|
+        assert_select ".forms_graduation_cadets_unit_id label", /#{cadet}/
+      end
+    end
+
+    test "omits users whose enlistments are not accepted" do
+      denied_enl = create(:enlistment, status: :denied, unit: @tp)
+      withdrawn_enl = create(:enlistment, status: :withdrawn, unit: @tp)
+
+      get graduate_manage_training_platoon_path(@tp)
+
+      refute_select ".forms_graduation_cadets_unit_id label", /#{denied_enl.user}/
+      refute_select ".forms_graduation_cadets_unit_id label", /#{withdrawn_enl.user}/
+    end
+
+    test "lists user timezone and recruiter unit" do
+      get graduate_manage_training_platoon_path(@tp)
+
+      assert_select ".forms_graduation_cadets_unit_id small", /PST/
+      assert_select ".forms_graduation_cadets_unit_id small", /S1/
+    end
+
+    test "unit selection only lists squads" do
+      create(:unit, name: "Second Squad", abbr: "S2")
+      create(:unit, name: "First Platoon", abbr: "P1")
+
+      get graduate_manage_training_platoon_path(@tp)
+
+      assert_select ".forms_graduation_cadets_unit_id select option", /S1/
+      assert_select ".forms_graduation_cadets_unit_id select option", /S2/
+      refute_select ".forms_graduation_cadets_unit_id select option", /P1/
+    end
+
+    test "unit selection includes unit size" do
+      create(:unit, name: "Second Squad", abbr: "S2")
+
+      get graduate_manage_training_platoon_path(@tp)
+
+      assert_select ".forms_graduation_cadets_unit_id select option", /S1 (1)/
+      assert_select ".forms_graduation_cadets_unit_id select option", /S2 (0)/
+    end
+
+    test "redirected to training platoon on success" do
+      assert_difference ["Assignment.count", "Promotion.count"], @cadets.size do
+        post graduate_manage_training_platoon_path(@tp), params: {
+          forms_graduation: {
+            cadets_attributes: modified_cadets_attributes,
+            award_ids: @awards.pluck(:id).prepend(""),
+            rank_id: @rank.id,
+            position_id: @position.id
+          }
+        }
+      end
+
+      assert_redirected_to manage_training_platoon_path(@tp)
+    end
+
+    test "throws validation error if any user assignment is omitted" do
+      modified_cadets_attributes = cadets_attributes.dup
+      modified_cadets_attributes.last["unit_id"] = ""
+
+      assert_no_difference "Assignment.count" do
+        post graduate_manage_training_platoon_path(@tp), params: {
+          forms_graduation: {
+            cadets_attributes: modified_cadets_attributes,
+            award_ids: @awards.pluck(:id).prepend(""),
+            rank_id: @rank.id,
+            position_id: @position.id
+          }
+        }
+      end
+
+      assert_select "#page_title", "Graduate"
+    end
+
+    test "re-renders previously selected form values when displaying validation errors" do
+      assert_no_difference "Assignment.count" do
+        post graduate_manage_training_platoon_path(@tp), params: {
+          forms_graduation: {
+            cadets_attributes: cadets_attributes,
+            award_ids: @awards.pluck(:id).prepend(""),
+            rank_id: @rank.id,
+            position_id: ""
+          }
+        }
+      end
+
+      assert_select ".forms_graduation_cadets_unit_id select option:selected", /#{@squad.abbr}/
+      assert_select "#forms_graduation_rank_id option:selected", @rank.name
+      assert_select "#forms_graduation_position_id option:selected", @position.name
+    end
+
+    private
+
+    def cadets_attributes
+      @cadets.each_with_index.reduce({}) do |accum, (cadet, index)|
+        accum[index.to_s] = {"id" => cadet.id, "unit_id" => @squad.id}
+      end
+    end
+  end
+end

--- a/test/models/forms/graduation_test.rb
+++ b/test/models/forms/graduation_test.rb
@@ -1,0 +1,145 @@
+require "test_helper"
+
+class Forms::GraduationTest < ActiveSupport::TestCase
+  setup do
+    @tp = create(:unit, classification: :training)
+
+    @cadets = create_list(:user, 5, rank_abbr: "Rec.")
+    @cadets.each do |cadet|
+      create(:enlistment, status: :accepted, unit: @tp, user: cadet)
+      create(:assignment, unit: @tp, user: cadet)
+    end
+
+    @squads = create_list(:unit, 5, name: "Squad") do |unit, index|
+      unit.name = "Squad #{index + 1}"
+    end
+
+    @cadets_attributes = @cadets.each_with_index.reduce({}) do |accum, (cadet, index)|
+      accum[index] = {"id" => cadet.id, "unit_id" => @squads[index]}
+    end
+
+    @awards = create_list(:award, 2)
+    @rank = create(:rank)
+    @position = create(:position, name: "Rifleman")
+
+    User.any_instance.stubs(:update_forum_display_name).returns(true)
+    User.any_instance.stubs(:update_forum_roles).returns(true)
+    User.any_instance.stubs(:update_coat).returns(true)
+  end
+
+  test "save rolls back if any cadet fails" do
+    modified_cadets_attributes = @cadets_attributes.dup
+    modified_cadets_attributes.last["unit_id"] = 999999
+    graduation = Forms::Graduation.new(unit: @tp, cadets_attributes: modified_cadets_attributes,
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id)
+
+    assert_no_difference ["Assignment.count", "Promotion.count", "Award.count"] do
+      refute graduation.save
+    end
+
+    @cadets.reload
+    @cadets.each do |cadet|
+      assert_equal "Rec.", cadet.rank.abbr
+    end
+  end
+
+  test "save rolls back if unit updates fail" do
+    graduation = Forms::Graduation.new(unit: @tp, cadets_attributes: @cadets_attributes,
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id)
+
+    Unit.any_instance.stub(:update!).raises(ActiveRecord::ActiveRecordError)
+
+    assert_no_difference ["Assignment.count", "Promotion.count", "Award.count"] do
+      refute graduation.save
+    end
+  end
+
+  test "does not allow graduating a user who is not part of the training platoon" do
+    non_member = create(:user)
+    modified_cadets_attributes = @cadets_attributes.dup
+    modified_cadets_attributes["999"] = {"id" => non_member.id, "unit_id" => @squads.first.id}
+    graduation = Forms::Graduation.new(unit: @tp, cadets_attributes: modified_cadets_attributes,
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id)
+
+    assert graduate.save
+
+    assert_nil non_member.assignments
+    assert_nil non_member.promotions
+    assert_nil non_member.awards
+  end
+
+  test "validates presence of all attributes before saving" do
+    skip
+  end
+
+  test "creates all awards, assignment, promotion records and updates user rank" do
+    graduation = Forms::Graduation.new(unit: @tp, cadets_attributes: @cadets_attributes,
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id)
+
+    assert graduation.save
+
+    @cadets.reload
+    @cadets.each do |cadet, index|
+      assert_equal @awards.size, cadet.awards
+      assert_equal 1, cadet.assignments.active.size
+      assert_equal @squads[index], cadet.assignments.active.first.unit
+      assert_equal 1, cadet.promotions.size
+      assert_equal @rank, cadet.rank
+    end
+  end
+
+  test "queues update_* background jobs" do
+    graduation = Forms::Graduation.new(unit: @tp, cadets_attributes: @cadets_attributes,
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id)
+
+    User.any_instance.expects(:update_forum_display_name)
+    User.any_instance.expects(:update_forum_roles)
+    User.any_instance.expects(:update_coat)
+
+    assert graduation.save
+  end
+
+  test "does not allow graduating a user who is already graduated" do
+    graduated_user = create(:user, rank_abbr: "PFC")
+    create(:enlistment, status: :accepted, unit: @tp, user: graduated_user)
+    create(:assignment, unit: @tp, user: graduated_user,
+      start_date: 2.weeks.ago, end_date: 1.week.ago)
+    create(:assignment, user: graduated_user, unit: @squads.first)
+
+    modified_cadets_attributes = @cadets_attributes.dup
+    modified_cadets_attributes["999"] = {"id" => graduated_user.id, "unit_id" => @squads.last.id}
+
+    graduation = Forms::Graduation.new(unit: @tp, cadets_attributes: modified_cadets_attributes,
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id)
+
+    assert graduation.save
+
+    graduated_user.reload
+    assert_equal 1, graduated_user.assignments.active
+    assert_equal @squads.first, graduated_user.assignments.active.first
+    assert_equal "PFC", graduated_user.rank.abbr
+  end
+
+  test "does not allow graduating a user whose enlistment is not accepted" do
+    denied_user = create(:user)
+    create(:enlistment, status: :denied, unit: @tp, user: denied_user)
+    create(:assignment, position: "Recruit", unit: @tp, user: denied_user,
+      start_date: 2.days.ago, end_date: 1.day.ago)
+
+    modified_cadets_attributes = @cadets_attributes.dup
+    modified_cadets_attributes["999"] = {"id" => graduated_user.id, "unit_id" => @squads.last.id}
+
+    graduation = Forms::Graduation.new(unit: @tp, cadets_attributes: modified_cadets_attributes,
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id)
+
+    assert graduation.save
+
+    denied_user.reload
+    assert_nil denied_user.assignments.active
+    refute_equal @rank, denied_user.rank
+  end
+
+  test "creates forum topic" do
+    skip
+  end
+end

--- a/test/models/forms/graduation_test.rb
+++ b/test/models/forms/graduation_test.rb
@@ -14,73 +14,82 @@ class Forms::GraduationTest < ActiveSupport::TestCase
       unit.name = "Squad #{index + 1}"
     end
 
-    @cadets_attributes = @cadets.each_with_index.reduce({}) do |accum, (cadet, index)|
-      accum[index] = {"id" => cadet.id, "unit_id" => @squads[index]}
+    @cadets_attributes = @cadets.each_with_index.each_with_object({}) do |(cadet, index), accum|
+      accum[index.to_s] = {"id" => cadet.id.to_s, "unit_id" => @squads[index].id.to_s}
     end
 
     @awards = create_list(:award, 2)
     @rank = create(:rank)
     @position = create(:position, name: "Rifleman")
 
-    User.any_instance.stubs(:update_forum_display_name).returns(true)
-    User.any_instance.stubs(:update_forum_roles).returns(true)
-    User.any_instance.stubs(:update_coat).returns(true)
+    cadet_delay_proxy = mock("delay_proxy")
+    Cadet.any_instance.stubs(:delay).returns(cadet_delay_proxy)
+    @cadet_stubs = cadet_delay_proxy.stubs(update_forum_display_name: true,
+      update_forum_roles: true, update_coat: true)
   end
 
   test "save rolls back if any cadet fails" do
     modified_cadets_attributes = @cadets_attributes.dup
-    modified_cadets_attributes.last["unit_id"] = 999999
+    last_key = modified_cadets_attributes.keys.last
+    modified_cadets_attributes[last_key]["unit_id"] = 999999
     graduation = Forms::Graduation.new(unit: @tp, cadets_attributes: modified_cadets_attributes,
-      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id)
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id,
+      topic_id: 0)
 
     assert_no_difference ["Assignment.count", "Promotion.count", "Award.count"] do
       refute graduation.save
     end
 
-    @cadets.reload
     @cadets.each do |cadet|
+      cadet.reload
       assert_equal "Rec.", cadet.rank.abbr
     end
   end
 
   test "save rolls back if unit updates fail" do
     graduation = Forms::Graduation.new(unit: @tp, cadets_attributes: @cadets_attributes,
-      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id)
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id,
+      topic_id: 0)
 
-    Unit.any_instance.stub(:update!).raises(ActiveRecord::ActiveRecordError)
+    Unit.any_instance.stubs(:update!).raises(ActiveRecord::RecordInvalid)
 
     assert_no_difference ["Assignment.count", "Promotion.count", "Award.count"] do
       refute graduation.save
     end
   end
 
-  test "does not allow graduating a user who is not part of the training platoon" do
-    non_member = create(:user)
-    modified_cadets_attributes = @cadets_attributes.dup
-    modified_cadets_attributes["999"] = {"id" => non_member.id, "unit_id" => @squads.first.id}
-    graduation = Forms::Graduation.new(unit: @tp, cadets_attributes: modified_cadets_attributes,
+  test "validates presence of all attributes" do
+    graduation_without_unit = Forms::Graduation.new(cadets_attributes: @cadets_attributes,
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id,
+      topic_id: 0)
+    graduation_without_cadets = Forms::Graduation.new(unit: @tp, topic_id: 0,
       award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id)
+    graduation_without_awards = Forms::Graduation.new(unit: @tp, cadets_attributes: @cadets_attributes,
+      rank_id: @rank.id, position_id: @position.id, topic_id: 0)
+    graduation_without_rank = Forms::Graduation.new(unit: @tp, cadets_attributes: @cadets_attributes,
+      award_ids: @awards.pluck(:id), position_id: @position.id, topic_id: 0)
+    graduation_without_position = Forms::Graduation.new(unit: @tp, cadets_attributes: @cadets_attributes,
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, topic_id: 0)
 
-    assert graduate.save
+    refute graduation_without_unit.valid?, "unit should be required"
+    refute graduation_without_cadets.valid?, "cadets should be required"
+    refute graduation_without_awards.valid?, "awards should be required"
+    refute graduation_without_rank.valid?, "rank should be required"
+    refute graduation_without_position.valid?, "position should be required"
 
-    assert_nil non_member.assignments
-    assert_nil non_member.promotions
-    assert_nil non_member.awards
-  end
-
-  test "validates presence of all attributes before saving" do
-    skip
+    refute graduation_without_unit.save, "didn't validate before saving"
   end
 
   test "creates all awards, assignment, promotion records and updates user rank" do
     graduation = Forms::Graduation.new(unit: @tp, cadets_attributes: @cadets_attributes,
-      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id)
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id,
+      topic_id: 0)
 
     assert graduation.save
 
-    @cadets.reload
-    @cadets.each do |cadet, index|
-      assert_equal @awards.size, cadet.awards
+    @cadets.each_with_index do |cadet, index|
+      cadet.reload
+      assert_equal @awards.size, cadet.user_awards.size
       assert_equal 1, cadet.assignments.active.size
       assert_equal @squads[index], cadet.assignments.active.first.unit
       assert_equal 1, cadet.promotions.size
@@ -90,53 +99,76 @@ class Forms::GraduationTest < ActiveSupport::TestCase
 
   test "queues update_* background jobs" do
     graduation = Forms::Graduation.new(unit: @tp, cadets_attributes: @cadets_attributes,
-      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id)
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id,
+      topic_id: 0)
 
-    User.any_instance.expects(:update_forum_display_name)
-    User.any_instance.expects(:update_forum_roles)
-    User.any_instance.expects(:update_coat)
+    @cadet_stubs.times(@cadets.size)
 
     assert graduation.save
   end
 
+  test "does not allow graduating a user who is not part of the training platoon" do
+    non_member = create(:user)
+    modified_cadets_attributes = @cadets_attributes.dup
+    modified_cadets_attributes["999"] = {"id" => non_member.id, "unit_id" => @squads.first.id}
+    graduation = Forms::Graduation.new(unit: @tp, cadets_attributes: modified_cadets_attributes,
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id,
+      topic_id: 0)
+
+    exception = assert_raises Forms::Graduation::IneligibleCadet do
+      graduation.save
+    end
+
+    assert_match(/#{non_member}/, exception.message)
+    assert_empty non_member.assignments, "user should have no assignments"
+    assert_empty non_member.promotions, "user should have no promotions"
+    assert_empty non_member.user_awards, "user should have no user_awards"
+  end
+
   test "does not allow graduating a user who is already graduated" do
-    graduated_user = create(:user, rank_abbr: "PFC")
-    create(:enlistment, status: :accepted, unit: @tp, user: graduated_user)
-    create(:assignment, unit: @tp, user: graduated_user,
+    already_graduated_user = create(:user, rank_abbr: "PFC")
+    create(:enlistment, status: :accepted, unit: @tp, user: already_graduated_user)
+    create(:assignment, unit: @tp, user: already_graduated_user,
       start_date: 2.weeks.ago, end_date: 1.week.ago)
-    create(:assignment, user: graduated_user, unit: @squads.first)
+    create(:assignment, user: already_graduated_user, unit: @squads.first)
 
     modified_cadets_attributes = @cadets_attributes.dup
-    modified_cadets_attributes["999"] = {"id" => graduated_user.id, "unit_id" => @squads.last.id}
+    modified_cadets_attributes["999"] = {"id" => already_graduated_user.id, "unit_id" => @squads.last.id}
 
     graduation = Forms::Graduation.new(unit: @tp, cadets_attributes: modified_cadets_attributes,
-      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id)
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id,
+      topic_id: 0)
 
-    assert graduation.save
+    assert_raises Forms::Graduation::IneligibleCadet do
+      graduation.save
+    end
 
-    graduated_user.reload
-    assert_equal 1, graduated_user.assignments.active
-    assert_equal @squads.first, graduated_user.assignments.active.first
-    assert_equal "PFC", graduated_user.rank.abbr
+    already_graduated_user.reload
+    assert_equal 1, already_graduated_user.assignments.active.size, "already graduated user should only have 1 active assignment"
+    assert_equal @squads.first, already_graduated_user.assignments.active.first.unit, "already graduated user's assignment shouldn't change"
+    assert_equal "PFC", already_graduated_user.rank.abbr, "already graduated user's rank shouldn't change"
   end
 
   test "does not allow graduating a user whose enlistment is not accepted" do
     denied_user = create(:user)
     create(:enlistment, status: :denied, unit: @tp, user: denied_user)
-    create(:assignment, position: "Recruit", unit: @tp, user: denied_user,
-      start_date: 2.days.ago, end_date: 1.day.ago)
+    create(:assignment, unit: @tp, user: denied_user, start_date: 2.days.ago,
+      end_date: 1.day.ago)
 
     modified_cadets_attributes = @cadets_attributes.dup
-    modified_cadets_attributes["999"] = {"id" => graduated_user.id, "unit_id" => @squads.last.id}
+    modified_cadets_attributes["999"] = {"id" => denied_user.id, "unit_id" => @squads.last.id}
 
     graduation = Forms::Graduation.new(unit: @tp, cadets_attributes: modified_cadets_attributes,
-      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id)
+      award_ids: @awards.pluck(:id), rank_id: @rank.id, position_id: @position.id,
+      topic_id: 0)
 
-    assert graduation.save
+    assert_raises Forms::Graduation::IneligibleCadet do
+      graduation.save
+    end
 
     denied_user.reload
-    assert_nil denied_user.assignments.active
-    refute_equal @rank, denied_user.rank
+    assert_empty denied_user.assignments.active, "denied user should have no active assignments"
+    refute_equal @rank, denied_user.rank, "denied user's rank should not change"
   end
 
   test "creates forum topic" do


### PR DESCRIPTION
Adds basic training platoon graduation functionality

![Screenshot 2024-03-24 at 14 35 37](https://github.com/29th/personnel-v3/assets/2887000/892c27b3-aecf-4516-8965-2d860a21ea54)

There are still a few things left to do for it to be complete, as described in the [milestone](https://github.com/orgs/29th/projects/1/views/3). Most importantly, it doesn't yet generate the forum topic, and it doesn't yet list the information that will be helpful for assignments (squad sizes, cadet timezone preference, recruiter unit). But I thought I'd publish what we have now and leave those for after.