### PR TITLE
Enforce Pundit authorization on every action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
 
   around_action :set_time_zone, if: :current_user
   # enforce policy for every action
-  after_action :verify_authorized, unless: -> { :active_admin_controller? }
+  after_action :verify_authorized, unless: :active_admin_controller?
 
   if Rails.env.development?
     around_action :n_plus_one_detection

--- a/app/controllers/discourse_webhooks_controller.rb
+++ b/app/controllers/discourse_webhooks_controller.rb
@@ -2,6 +2,7 @@ class DiscourseWebhooksController < ApplicationController
   SECRET_KEY = Settings.discourse.webhooks_secret
   before_action :verify_webhook_token
   skip_before_action :verify_authenticity_token
+  skip_after_action :verify_authorized # authenticated by webhook signature instead
 
   # When a forum account is activated (email confirmed), check the
   # personnel database for an existing user with that email (from

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,4 +1,6 @@
 class HomeController < ApplicationController
+  skip_after_action :verify_authorized # public informational pages
+
   layout "about", except: :landing
 
   def landing

--- a/app/controllers/reverse_proxy_controller.rb
+++ b/app/controllers/reverse_proxy_controller.rb
@@ -4,6 +4,8 @@
 class ReverseProxyController < ApplicationController
   include ReverseProxy::Controller
 
+  skip_after_action :verify_authorized # public legacy proxies and redirects
+
   before_action :force_trailing_slash
 
   SITES = {

--- a/app/controllers/roster_controller.rb
+++ b/app/controllers/roster_controller.rb
@@ -1,4 +1,6 @@
 class RosterController < ApplicationController
+  skip_after_action :verify_authorized # the roster is public
+
   def index
     units = Unit.find_root.subtree.active
     @unit_tree = units.arrange(order: :order)

--- a/test/controllers/authorization_enforcement_test.rb
+++ b/test/controllers/authorization_enforcement_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+# ApplicationController requires every action to run a Pundit authorization
+# check (verify_authorized). These tests guard the guard: if that after_action
+# is ever disabled again, the first test below starts failing.
+#
+# They use ActionController::TestCase with a private route set so the fake
+# controllers don't touch the application's real routes.
+module AuthorizationEnforcement
+  class ForgetfulPagesController < ApplicationController
+    def show
+      head :ok
+    end
+  end
+
+  class PublicPagesController < ApplicationController
+    def show
+      skip_authorization
+      head :ok
+    end
+  end
+
+  ROUTES = ActionDispatch::Routing::RouteSet.new.tap do |routes|
+    routes.draw do
+      get "forgetful_page" => "authorization_enforcement/forgetful_pages#show"
+      get "public_page" => "authorization_enforcement/public_pages#show"
+    end
+  end
+
+  class ForgetfulPagesControllerTest < ActionController::TestCase
+    setup { @routes = ROUTES }
+
+    test "an action that never calls authorize raises instead of serving the page" do
+      assert_raises Pundit::AuthorizationNotPerformedError do
+        get :show
+      end
+    end
+  end
+
+  class PublicPagesControllerTest < ActionController::TestCase
+    setup { @routes = ROUTES }
+
+    test "an action that explicitly skips authorization is served" do
+      get :show
+
+      assert_response :success
+    end
+  end
+end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -5,4 +5,17 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get root_url
     assert_response :success
   end
+
+  test "public informational pages render" do
+    create(:server) # /servers groups active servers by game
+
+    %w[
+      /about /about/awards /about/realism /about/ranks /about/historical
+      /about/server /about/faq /about/record /about/ourhistory
+      /contact /donate /servers /enlist
+    ].each do |path|
+      get path
+      assert_response :success, "expected #{path} to render"
+    end
+  end
 end

--- a/test/controllers/reverse_proxy_controller_test.rb
+++ b/test/controllers/reverse_proxy_controller_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class ReverseProxyControllerTest < ActionDispatch::IntegrationTest
+  test "legacy paths are redirected to add a trailing slash" do
+    get "/bans"
+
+    assert_response :moved_permanently
+    assert_match %r{/bans/$}, response.location
+  end
+
+  test "legacy routes redirect without requiring authentication" do
+    get "/bans/"
+
+    assert_response :redirect
+    assert_match "forums.29th.org", response.location
+  end
+end


### PR DESCRIPTION
The verify_authorized after_action was passing a lambda that returned a symbol to unless:, which is always truthy, so the check never ran anywhere. Fix the condition, explicitly skip it in the controllers that are intentionally public (home, roster, reverse proxy) or authenticated by other means (webhook signatures), and add tests that fail if the enforcement is ever disabled again.


Claude-Session: https://claude.ai/code/session_01EyfmZ4Gf9oDDp39TYhSstR