### PR TITLE
Add seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,36 @@ A rewrite of the [personnel management system](https://github.com/29th/personnel
 ### Prerequisites
 - [Docker](https://docs.docker.com/install/)
 
-### Database snapshot
-To load your database with data, you'll need to put a database dump (`.sql`) file in the `db/dump/`
-directory. You can get this from another team member, or you can export a dump of the production
-database by SSHing into the production server and running:
+### Database
+With a MySQL server running (e.g. `docker compose up db`), create the schema and
+load it with generated sample data:
+
+```
+bin/rails db:prepare db:seed
+```
+
+Seeding takes about a minute and produces a realistic, PII-free dataset modelled
+on production: the active unit hierarchy, ~335 members with careers (enlistments,
+promotions, awards, qualifications, discharges) and three years of events and
+attendance. Real reference data (ranks, positions, awards, abilities, AIT
+standards) lives in `db/seeds/data/`; everything personal is fake. To sign in,
+use the navbar's **Sign in (dev)** button with one of the `forum_member_id`
+values printed at the end of seeding (e.g. the Regiment Commander for full
+admin access). To start over, run `bin/rails db:reset`.
+
+#### Alternative: database snapshot
+If you're a team member and need real data, you can instead put a database dump
+(`.sql`) file in the `db/dump/` directory (Docker imports it on first startup).
+You can get this from another team member, or you can export a dump of the
+production database by SSHing into the production server and running:
 
 ```
 mysqldump -u <username> -p <database> > dump.sql
 ```
 
-Put the `dump.sql` file in the `db/dump/` directory.
+Put the `dump.sql` file in the `db/dump/` directory. Note dumps contain personal
+data (names, emails, Steam IDs, IPs) and must never be committed or shared
+outside the team.
 
 ### Running the application
 Use [29th/personnel](https://github.com/29th/personnel) to run this application,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,55 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
+# Generates a representative, PII-free development dataset.
 #
-# Examples:
+# The shape of this data (org structure, career/churn patterns, rank pyramid,
+# event cadence, attendance rates) is modelled on aggregate statistics from a
+# production database dump, so a seeded environment feels like the real app.
+# All names, emails, steam IDs and free text are fake. Reference tables
+# (ranks, positions, abilities, awards, countries, AIT standards) are real,
+# non-personal config extracted from production into db/seeds/data/.
 #
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+# Seeding is deterministic for a given day: the RNG is fixed, but dates are
+# generated relative to Date.current so "active" data stays recent.
+#
+# Usage: bin/rails db:seed (also runs via db:prepare when the db is created)
+
+return if Rails.env.test?
+
+if User.exists?
+  abort("Refusing to seed: the database already contains data. " \
+        "Run `bin/rails db:reset` to drop, recreate and reseed.")
+end
+
+require "faker"
+
+srand(29)
+Faker::Config.random = Random.new(29)
+
+# Auditing every generated record would triple the insert volume for no value
+Audited.auditing_enabled = false
+
+started_at = Time.current
+Dir[Rails.root.join("db/seeds/[0-9]*.rb")].sort.each do |file|
+  puts "== #{File.basename(file)}"
+  load file
+end
+Audited.auditing_enabled = true
+
+puts <<~SUMMARY
+  Seeded in #{(Time.current - started_at).round(1)}s:
+    #{Unit.count} units (#{Unit.active.count} active)
+    #{User.count} users (#{User.active.count} with an active assignment)
+    #{Assignment.count} assignments, #{Enlistment.count} enlistments, #{Discharge.count} discharges
+    #{Promotion.count} promotions, #{UserAward.count} awardings, #{AITQualification.count} qualifications
+    #{Event.count} events, #{AttendanceRecord.count} attendance records
+SUMMARY
+
+# In development you can use the navbar's "Sign in (dev)" button with a
+# forum_member_id to act as any seeded user
+persona = ->(position_name) do
+  user = Assignment.active.joins(:position)
+    .find_by(positions: {name: position_name})&.user
+  puts "    #{user.forum_member_id}  #{user.short_name} (#{position_name})" if user
+end
+puts "  Dev sign-in personas (forum_member_id):"
+["Regiment Commander", "Commanding Officer", "Squad Leader", "Rifleman", "Recruit"]
+  .each { |position_name| persona.call(position_name) }

--- a/db/seeds/01_reference_data.rb
+++ b/db/seeds/01_reference_data.rb
@@ -1,0 +1,27 @@
+# Real (non-personal) reference data extracted from production: the rank
+# ladder, position catalogue, authorization abilities, awards, countries,
+# AIT standards and game servers. Server addresses/ports are faked.
+
+{
+  Rank => "ranks.yml",
+  Position => "positions.yml",
+  Ability => "abilities.yml",
+  Award => "awards.yml",
+  Country => "countries.yml",
+  Server => "servers.yml"
+}.each do |model, file|
+  rows = YAML.load_file(Rails.root.join("db/seeds/data", file))
+  model.insert_all(rows)
+  puts "   #{model.table_name}: #{rows.size}"
+end
+
+# The EIB and SLT standards predate the game column and store a legacy empty
+# enum value, which AITStandard's enum would cast to NULL. Insert through a
+# cast-free stub model with strict mode off — the same way a production dump
+# import replays them.
+standards_stub = Class.new(ApplicationRecord) { self.table_name = "standards" }
+rows = YAML.load_file(Rails.root.join("db/seeds/data/ait_standards.yml"))
+standards_stub.connection.execute("SET SESSION sql_mode = ''")
+standards_stub.insert_all(rows)
+standards_stub.connection.execute("SET SESSION sql_mode = DEFAULT")
+puts "   standards: #{rows.size}"

--- a/db/seeds/02_units.rb
+++ b/db/seeds/02_units.rb
@@ -1,0 +1,122 @@
+# The unit tree mirrors the real (public) active org chart: a regiment with
+# two battalions of game-specific companies, an HQ staff branch, and training
+# platoons under Lighthouse Corps. Historical (inactive) units are included
+# so discharged members' old assignments have realistic targets.
+
+ORDINALS = %w[First Second Third Fourth]
+TP_GAME_ABBR = {dh: "DH", rs: "RS", arma3: "A3", rs2: "RS2", squad: "SQ"}
+TP_GAME_NAME = {dh: "Darkest Hour", rs: "Rising Storm", arma3: "Arma 3",
+                rs2: "Rising Storm 2", squad: "Squad"}
+
+# Registry of training platoons by month, used by 04_members.rb to assign
+# each member's basic training to a platoon matching their enlistment date
+TRAINING_PLATOONS = []
+
+@unit_order = 0
+
+def seed_unit!(name:, abbr:, classification:, parent: nil, **attrs)
+  unit = Unit.new(name:, abbr:, classification:, parent:,
+    order: (@unit_order += 1), **attrs)
+  unit[:class] = classification.to_s.capitalize # legacy v2 column
+  unit.path = "/" if parent.nil? # legacy column; a callback sets it for non-roots
+  unit.save!
+  unit
+end
+
+def seed_company!(parent:, name:, letter:, game:, platoons:, active: true)
+  company = seed_unit!(name: "#{name} Company", abbr: "#{name} Co. HQ",
+    classification: :combat, parent:, game:, active:,
+    slogan: Faker::Company.catch_phrase, nickname: name)
+  platoons.each_with_index do |squad_count, pi|
+    platoon = seed_unit!(name: "#{name} Company, #{ORDINALS[pi]} Platoon",
+      abbr: "#{letter}P#{pi + 1} HQ", classification: :combat,
+      parent: company, game:, active:)
+    squad_count.times do |si|
+      # last squad of each platoon drills on a European schedule
+      timezone = (si == squad_count - 1) ? :gmt : :est
+      seed_unit!(name: "#{name} Company, #{ORDINALS[pi]} Platoon, #{ORDINALS[si]} Squad",
+        abbr: "#{letter}P#{pi + 1}S#{si + 1}", classification: :combat,
+        parent: platoon, game:, active:, timezone:)
+    end
+  end
+  company
+end
+
+def seed_training_platoon!(parent:, month:, game:, active:)
+  unit = seed_unit!(
+    name: "#{month.strftime("%B %Y")} Training Platoon #{TP_GAME_NAME[game]}",
+    abbr: "TP #{month.strftime("%y%m")} #{TP_GAME_ABBR[game]}",
+    classification: :training, parent:, game:, active:
+  )
+  TRAINING_PLATOONS << {unit:, month:, game:}
+end
+
+regiment = seed_unit!(name: "116th Infantry Regiment", abbr: "Regt. HQ",
+  classification: :combat, slogan: "Ever Forward")
+
+bn1 = seed_unit!(name: "First Battalion", abbr: "1st Bn. HQ",
+  classification: :combat, parent: regiment)
+seed_company!(parent: bn1, name: "Charlie", letter: "C", game: :arma3, platoons: [2, 2])
+seed_company!(parent: bn1, name: "Dog", letter: "D", game: :rs2, platoons: [3, 4])
+
+bn2 = seed_unit!(name: "Second Battalion", abbr: "2nd Bn. HQ",
+  classification: :combat, parent: regiment)
+seed_company!(parent: bn2, name: "Easy", letter: "E", game: :squad, platoons: [3, 3, 3])
+seed_company!(parent: bn2, name: "Fox", letter: "F", game: :squad, platoons: [3, 3])
+
+# Disbanded companies from earlier games; homes for old ended assignments
+seed_company!(parent: bn1, name: "Able", letter: "A", game: :dh, platoons: [2, 2], active: false)
+seed_company!(parent: bn1, name: "Baker", letter: "B", game: :rs, platoons: [2], active: false)
+
+staff = seed_unit!(name: "Headquarters Staff", abbr: "Staff",
+  classification: :staff, parent: regiment)
+lighthouse = nil
+{
+  "S-1 Personnel" => ["Adjutant Corps Adj", "Finance Corps Fin", "Quartermaster Corps Quart"],
+  "S-2 Intelligence" => ["Military Police Corps MP"],
+  "S-3 Operations" => ["Civil Affairs Corps Civ", "Lighthouse Corps LH", "Operations Corps Oper", "Signal Corps Sig"],
+  "S-4 Logistics" => ["Engineer Corps Eng", "Medical Corps Med", "Ordnance Corps Ord"]
+}.each do |office_name, corps|
+  office = seed_unit!(name: office_name, abbr: office_name.split(" ").first,
+    classification: :staff, parent: staff)
+  corps.each do |corps_entry|
+    *name_words, abbr = corps_entry.split(" ")
+    corps_unit = seed_unit!(name: name_words.join(" "), abbr:,
+      classification: :staff, parent: office)
+    lighthouse = corps_unit if abbr == "LH"
+  end
+end
+
+seed_unit!(name: "Recruit Pool (Awaiting BCT Assignment)", abbr: "Recruit Pool",
+  classification: :training, parent: lighthouse)
+# Reserved stub unit; Unit.training_platoons excludes it by name
+seed_unit!(name: "Training Platoons", abbr: "TPs",
+  classification: :training, parent: lighthouse)
+
+# Monthly training platoons covering the last 3 years (two games per month,
+# rotating), matching the ~2-3 platoons/month production cadence. Only the
+# most recent month's platoons are still active.
+game_rotation = [%i[squad rs2], %i[squad arma3], %i[rs2 arma3]]
+35.downto(0) do |months_ago|
+  month = months_ago.months.ago.to_date.beginning_of_month
+  game_rotation[month.month % 3].each do |game|
+    seed_training_platoon!(parent: lighthouse, month:, game:,
+      active: months_ago <= 1)
+  end
+end
+
+# Sparser, older platoons so long-tenured veterans have a basic training
+# unit from their era
+(12..32).each do |quarters_ago|
+  month = (quarters_ago * 3).months.ago.to_date.beginning_of_month
+  game = (quarters_ago > 24) ? :dh : ((quarters_ago > 18) ? :rs : :rs2)
+  seed_training_platoon!(parent: lighthouse, month:, game:, active: false)
+end
+
+seed_unit!(name: "Reserve Platoon", abbr: "Rsrv S1",
+  classification: :combat, parent: regiment)
+
+seed_unit!(name: "Squad Leadership Training", abbr: "SLT", classification: :staff)
+seed_unit!(name: "Temporary Admins", abbr: "Admins", classification: :staff)
+
+puts "   units: #{Unit.count} (#{Unit.active.count} active)"

--- a/db/seeds/03_permissions.rb
+++ b/db/seeds/03_permissions.rb
@@ -1,0 +1,148 @@
+# Unit permission matrix, modelled on the real configuration: each echelon
+# grants a standard set of abilities per access level (member=0 is anyone in
+# the unit, elevated=5 clerks, leader=10 unit leadership). A user holds an
+# ability when their position's access level meets the permission's level.
+
+PERMISSION_TEMPLATES = {
+  squad: {
+    member: %w[event_aar],
+    leader: %w[banlog_edit_any event_aar_any manage note_view_sq
+      qualification_add qualification_delete]
+  },
+  platoon: {
+    elevated: %w[admin-awardings admin-events admin-promotions
+      admin-weapon_passes assignment_add awarding_add event_aar event_add
+      manage profile_edit promotion_add],
+    leader: %w[assignment_delete awarding_delete banlog_edit_any event_aar_any
+      note_view_pl promotion_delete qualification_add qualification_delete]
+  },
+  company: {
+    member: %w[admin-awardings admin-events assignment_add banlog_edit_any
+      discharge_add event_aar_any event_add manage],
+    elevated: %w[admin-promotions admin-weapon_passes assignment_add_any
+      assignment_delete awarding_add awarding_delete profile_edit
+      promotion_add],
+    leader: %w[admin-discharges demerit_add eloa_add_any note_view_co
+      promotion_delete qualification_add qualification_delete]
+  },
+  battalion: {
+    elevated: %w[admin-awardings admin-discharges admin-events
+      admin-promotions admin-weapon_passes assignment_add assignment_add_any
+      assignment_delete banlog_edit_any discharge_add event_aar_any event_add
+      manage profile_edit promotion_add],
+    leader: %w[awarding_add awarding_delete demerit_add eloa_add_any
+      note_view_co promotion_delete qualification_add qualification_delete]
+  },
+  regiment: {
+    member: %w[admin admin-events admin-notes admin-weapon_passes
+      assignment_add_any assignment_delete_any banlog_edit_any demerit_add_any
+      discharge_add_any eloa_add_any enlistment_edit_any enlistment_process_any
+      event_aar_any event_add_any event_view_any finance_view_any manage
+      note_view_all profile_edit profile_edit_any profile_view_any
+      promotion_add_any qualification_add_any qualification_delete_any
+      unit_add]
+  },
+  s1: {
+    member: %w[admin-awardings admin-eloas admin-notes admin-weapon_passes
+      banlog_edit_any demerit_add_any eloa_view_any event_add_any
+      finance_view_any manage note_view_all],
+    leader: %w[admin-attendance admin-discharges admin-events admin-finances
+      admin-promotions assignment_add assignment_add_any assignment_delete
+      assignment_delete_any discharge_add_any eloa_add_any event_aar_any
+      finance_add promotion_add promotion_delete]
+  },
+  lighthouse: {
+    member: %w[admin-weapon_passes enlistment_assign_any enlistment_edit_any
+      enlistment_process_any event_aar manage note_view_lh pass_edit_any
+      profile_edit restricted_name_view_any],
+    elevated: %w[admin-enlistments admin-events admin-units assignment_add
+      event_add unit_add],
+    leader: %w[note_view_pl promotion_add]
+  },
+  military_police: {
+    member: %w[admin-banlog banlog_edit_any manage],
+    elevated: %w[note_view_mp],
+    leader: %w[assignment_add demerit_add_any]
+  },
+  adjutant: {
+    member: %w[eloa_add_any manage],
+    elevated: %w[admin-eloas],
+    leader: %w[assignment_add demerit_add_any note_view_pl]
+  },
+  finance: {
+    member: %w[admin-finances admin-weapon_passes finance_add manage
+      pass_edit_any],
+    leader: %w[admin-awardings assignment_add note_view_pl]
+  },
+  staff_corps: {
+    member: %w[event_aar manage],
+    leader: %w[assignment_add event_add note_view_pl]
+  },
+  reserve: {
+    leader: %w[admin-awardings admin-discharges admin-promotions
+      assignment_add_any awarding_add_any awarding_delete demerit_add
+      discharge_add eloa_add_any manage note_view_co profile_edit
+      promotion_add promotion_delete]
+  },
+  admins: {
+    member: %w[admin admin-attendance admin-awardings admin-banlog
+      admin-discharges admin-enlistments admin-notes admin-promotions
+      admin-units assignment_add_any assignment_delete_any award_add
+      awarding_add_any discharge_add_any enlistment_edit_any
+      enlistment_process_any event_aar_any manage profile_edit_any
+      promotion_add_any promotion_delete_any qualification_add_any
+      qualification_delete_any unit_add]
+  }
+}
+
+def permission_template_for(unit)
+  case unit.abbr
+  when "Regt. HQ" then :regiment
+  when /Bn\. HQ$/ then :battalion
+  when /Co\. HQ$/ then :company
+  when /P\d HQ$/ then :platoon
+  when "S-1" then :s1
+  when "LH" then :lighthouse
+  when "MP" then :military_police
+  when "Adj" then :adjutant
+  when "Fin" then :finance
+  when "Rsrv S1" then :reserve
+  when "Admins" then :admins
+  else
+    if unit.combat? && unit.name.include?("Squad")
+      :squad
+    elsif unit.staff?
+      :staff_corps
+    end
+  end
+end
+
+ability_ids = Ability.pluck(:abbr, :id).to_h
+access_levels = {member: 0, elevated: 5, leader: 10}
+permission_rows = []
+
+Unit.active.find_each do |unit|
+  template = PERMISSION_TEMPLATES[permission_template_for(unit)]
+  next unless template
+
+  template.each do |level, abbrs|
+    abbrs.each do |abbr|
+      permission_rows << {unit_id: unit.id,
+                          access_level: access_levels.fetch(level),
+                          ability_id: ability_ids.fetch(abbr)}
+    end
+  end
+end
+Permission.insert_all(permission_rows)
+
+# Legacy v2 class-wide permissions (no v3 model, but kept populated for parity)
+class_permission = Class.new(ApplicationRecord) { self.table_name = "class_permissions" }
+class_permission.insert_all(
+  [[nil, "profile_view_any"]]
+    .concat(%w[event_view_any unit_stats_any finance_view_any eloa_view_any
+      demerit_view_any note_view_any banlog_view_any qualification_view_any]
+      .flat_map { |abbr| [["Combat", abbr], ["Staff", abbr]] })
+    .map { |klass, abbr| {"class" => klass, "ability_id" => ability_ids.fetch(abbr)} }
+)
+
+puts "   unit_permissions: #{Permission.count}"

--- a/db/seeds/04_members.rb
+++ b/db/seeds/04_members.rb
@@ -1,0 +1,532 @@
+# Members and their careers. Modelled on production patterns:
+# - an active roster of ~270 filling every squad, HQ and staff corps, with
+#   tenure-appropriate ranks and promotion history (a bottom-heavy pyramid)
+# - ~1,100 historical members over 3 years reflecting the real enlistment
+#   funnel (~52% accepted, ~21% withdrawn, ~17% AWOL, ~10% denied), most of
+#   whom churn out within weeks and end discharged General/Honorable
+# - awards, AIT qualifications, ELOAs, passes, notes and (rare) demerits at
+#   production-like per-member rates
+
+RANKS = Rank.all.index_by(&:abbr)
+POSITIONS = Position.all.index_by(&:name)
+COUNTRY_IDS = Country.pluck(:abbr, :id).to_h
+
+# Ranks are earned in ladder order; clerks sometimes top out as technicians
+RANK_LADDER = ["Rec.", "Pvt.", "PFC", "Cpl.", "Sgt.", "SSgt.", "TSgt.",
+  "MSgt.", "FSgt.", "2Lt.", "1Lt.", "Cpt.", "Maj.", "Lt. Col.", "Col."]
+TECHNICIAN_LADDER = ["Rec.", "Pvt.", "PFC", "T/5", "T/4", "T/3"]
+
+USER_TIME_ZONES = ["Eastern Time (US & Canada)", "Central Time (US & Canada)",
+  "Pacific Time (US & Canada)", "London", "Amsterdam", "Sydney", "UTC"]
+WEIGHTED_COUNTRIES = %w[US US US US US GB GB CA CA AU DE NL SE PL FR NO]
+
+BCT_DAYS = 28 # basic training length; drives TP assignment windows
+
+@next_forum_member_id = 1000
+@member_profiles = [] # metadata consumed by the enlistment/extras passes
+
+def fake_steam_id = "7656119#{format("%010d", rand(10_000_000_000))}"
+
+# Which forum software hosted the paper trail at that point in history
+def forum_for(date)
+  (date < 4.years.ago.to_date) ? "Vanilla" : "Discourse"
+end
+
+def fake_topic_id = rand(1_000..99_999)
+
+def training_platoon_for(date, game)
+  month = date.beginning_of_month
+  candidates = TRAINING_PLATOONS.select { |tp| tp[:month] == month }
+  exact = candidates.find { |tp| tp[:game] == game }
+  (exact || candidates.first ||
+    TRAINING_PLATOONS.min_by { |tp| (tp[:month] - month).abs })[:unit]
+end
+
+def sample_tenure_days
+  case rand
+  when 0..0.20 then rand(30..120)
+  when 0.20..0.60 then rand(120..550)
+  when 0.60..0.85 then rand(550..1_100)
+  else rand(1_100..2_900)
+  end
+end
+
+def create_user!(rank_abbr:, enlist_date:, game:)
+  first_name = Faker::Name.first_name
+  last_name = Faker::Name.last_name
+  User.create!(
+    first_name:, last_name:,
+    middle_name: (rand < 0.3) ? ("A".."Z").to_a.sample : nil,
+    rank: RANKS.fetch(rank_abbr),
+    steam_id: fake_steam_id,
+    email: Faker::Internet.email(name: "#{first_name} #{last_name}"),
+    time_zone: USER_TIME_ZONES.sample,
+    country_id: (rand < 0.9) ? COUNTRY_IDS[WEIGHTED_COUNTRIES.sample] : nil,
+    forum_member_id: (@next_forum_member_id += 1),
+    vanilla_forum_member_id: (enlist_date < 4.years.ago.to_date) ? @next_forum_member_id : nil
+  ).tap do |user|
+    @member_profiles << {user:, enlist_date:, game:, career_end: nil,
+                         graduated: true, enlist_status: :accepted}
+  end
+end
+
+@promotion_rows = []
+
+# Promotions climbing the ladder from Recruit to target_abbr, spread across
+# the member's service. Median gap between promotions in production is ~176
+# days (p25 106, p75 349).
+def plan_promotions!(user, target_abbr, enlist_date, end_date)
+  ladder = TECHNICIAN_LADDER.include?(target_abbr) ? TECHNICIAN_LADDER : RANK_LADDER
+  rungs = ladder[1..ladder.index(target_abbr)] || []
+  return if rungs.empty?
+
+  graduation = enlist_date + BCT_DAYS
+  span = (end_date - graduation).to_i
+  avg_gap = [span / rungs.size, 1].max
+  date = graduation
+  previous = RANKS.fetch("Rec.")
+  rungs.each_with_index do |abbr, i|
+    date += (i.zero? ? 0 : (avg_gap * rand(0.6..1.4)).to_i)
+    date = [date, end_date].min
+    rank = RANKS.fetch(abbr)
+    @promotion_rows << {member_id: user.id, date:, old_rank_id: previous.id,
+                        new_rank_id: rank.id, forum_id: forum_for(date),
+                        topic_id: fake_topic_id}
+    previous = rank
+  end
+end
+
+def assign!(user, unit, position_name, start_date, end_date = nil)
+  Assignment.create!(user:, unit:, position: POSITIONS.fetch(position_name),
+    start_date:, end_date:)
+end
+
+# An active member: enlisted `tenure_days` ago, did BCT, now holds `position`
+# in `unit` (with an optional earlier assignment elsewhere in the company)
+def seed_active_member!(unit:, position:, rank:, tenure_days:, previous_unit: nil)
+  enlist_date = Date.current - tenure_days
+  user = create_user!(rank_abbr: rank, enlist_date:, game: unit.game || "squad")
+
+  tp = training_platoon_for(enlist_date, unit.game)
+  assign!(user, tp, "Recruit", enlist_date + 2, enlist_date + BCT_DAYS)
+
+  current_start = enlist_date + BCT_DAYS
+  if previous_unit && tenure_days > 540
+    transfer_date = Date.current - rand(90..360)
+    assign!(user, previous_unit, "Rifleman", current_start, transfer_date)
+    current_start = transfer_date
+  end
+  assign!(user, unit, position, current_start)
+
+  plan_promotions!(user, rank, enlist_date, Date.current - rand(0..60))
+  user
+end
+
+active_squads = Unit.active.combat.where("name LIKE ?", "%Squad%").order(:abbr)
+squad_member_positions = ["Rifleman"] * 5 + ["Grenadier", "Submachine Gunner",
+  "Combat Engineer", "First Class Automatic Rifleman",
+  "Second Class Automatic Rifleman"]
+
+active_squads.each do |squad|
+  siblings = squad.siblings.where("name LIKE ?", "%Squad%").where.not(id: squad.id)
+  seed_active_member!(unit: squad, position: "Squad Leader",
+    rank: %w[Sgt. SSgt.].sample, tenure_days: rand(700..2_500))
+  seed_active_member!(unit: squad, position: "Asst. Squad Leader",
+    rank: %w[Cpl. Sgt.].sample, tenure_days: rand(400..1_500))
+  rand(6..9).times do
+    tenure_days = sample_tenure_days
+    rank = if tenure_days < 240
+      "Pvt."
+    elsif tenure_days < 550
+      "PFC"
+    else
+      ["Cpl.", "Cpl.", "T/5", "Sgt."].sample
+    end
+    seed_active_member!(unit: squad, position: squad_member_positions.sample,
+      rank:, tenure_days:,
+      previous_unit: (rand < 0.25) ? siblings.sample : nil)
+  end
+end
+
+Unit.active.combat.where("abbr LIKE ?", "%P_ HQ").find_each do |platoon|
+  seed_active_member!(unit: platoon, position: "Platoon Leader",
+    rank: %w[2Lt. 1Lt.].sample, tenure_days: rand(900..2_700))
+  seed_active_member!(unit: platoon, position: "Platoon Sergeant",
+    rank: %w[TSgt. MSgt.].sample, tenure_days: rand(900..2_700))
+  seed_active_member!(unit: platoon, position: "Platoon Clerk",
+    rank: "T/5", tenure_days: rand(250..1_100))
+  if rand < 0.6
+    seed_active_member!(unit: platoon, position: "Platoon Sniper",
+      rank: "PFC", tenure_days: rand(250..1_100))
+  end
+end
+
+Unit.active.combat.where("abbr LIKE ?", "%Co. HQ").find_each do |company|
+  seed_active_member!(unit: company, position: "Commanding Officer",
+    rank: "Cpt.", tenure_days: rand(1_400..2_900))
+  seed_active_member!(unit: company, position: "Executive Officer",
+    rank: "1Lt.", tenure_days: rand(1_100..2_700))
+  seed_active_member!(unit: company, position: "First Sergeant",
+    rank: "FSgt.", tenure_days: rand(1_100..2_700))
+  seed_active_member!(unit: company, position: "Company Clerk",
+    rank: "T/4", tenure_days: rand(400..1_400))
+end
+
+Unit.active.combat.where("abbr LIKE ?", "%Bn. HQ").find_each do |battalion|
+  seed_active_member!(unit: battalion, position: "Battalion Commander",
+    rank: %w[Maj. Lt.\ Col.].sample, tenure_days: rand(1_800..2_900))
+  seed_active_member!(unit: battalion, position: "Battalion Executive Officer",
+    rank: "Cpt.", tenure_days: rand(1_400..2_700))
+  seed_active_member!(unit: battalion, position: "Battalion SNCO",
+    rank: "Sgt. Maj", tenure_days: rand(1_400..2_700))
+end
+
+regiment = Unit.find_root
+seed_active_member!(unit: regiment, position: "Regiment Commander",
+  rank: "Col.", tenure_days: rand(2_200..2_900))
+seed_active_member!(unit: regiment, position: "Regiment SNCO",
+  rank: "CSM", tenure_days: rand(1_800..2_900))
+seed_active_member!(unit: regiment, position: "Regiment Clerk",
+  rank: "Sgt.", tenure_days: rand(700..1_800))
+
+reserve = Unit.find_by!(abbr: "Rsrv S1")
+seed_active_member!(unit: reserve, position: "Chief Reservist",
+  rank: "SSgt.", tenure_days: rand(1_800..2_900))
+4.times do
+  seed_active_member!(unit: reserve, position: "Reservist",
+    rank: %w[Cpl. Sgt. SSgt.].sample, tenure_days: rand(1_100..2_900))
+end
+
+# Staff corps are mostly dual-hatted combat members plus a couple of
+# staff-only veterans; gives the 1-3 concurrent assignments seen in prod
+STAFF_POSITIONS = {
+  "Adj" => ["Chief of Adjutant Corps", "Adjutant Clerk", "ELOA Adjutant", "Attendance Adjutant"],
+  "Fin" => ["Chief Finance Officer", "Finance Officer", "Finance Clerk"],
+  "Quart" => ["Chief of Quartermaster Corps", "Quartermaster"],
+  "MP" => ["Chief of Military Police Corps", "Military Police Officer", "Military Police Officer"],
+  "Civ" => ["Chief of Civil Affairs Corps", "War Correspondent - SQ", "Print Journalist"],
+  "LH" => ["Chief of Lighthouse Corps", "Enlistment Liaison - SQ", "Enlistment Liaison - A3",
+    "Enlistment Liaison - RS2", "Drill Instructor - SQ", "Asst. Drill Instructor - A3"],
+  "Oper" => ["Chief of Operations Corps", "Scrimmage Admin"],
+  "Sig" => ["Chief of Signal Corps", "Signal Corps Community Contact", "Signal Corps Clerk"],
+  "Eng" => ["Chief of Engineer Corps", "Code Technician", "Web Technician"],
+  "Med" => ["Chief of Medical Corps", "Medical Technician"],
+  "Ord" => ["Chief of Ordnance Corps", "Ordnance Instructor", "Ordnance Instructor"]
+}
+
+nco_pool = @member_profiles
+  .select { |p| p[:user].rank.order >= RANKS.fetch("Cpl.").order }
+  .shuffle
+
+STAFF_POSITIONS.each do |abbr, position_names|
+  corps = Unit.find_by!(abbr:)
+  position_names.each do |position_name|
+    profile = nco_pool.pop
+    break if profile.nil?
+    start = [profile[:enlist_date] + rand(200..400), Date.current - 30].min
+    assign!(profile[:user], corps, position_name, start)
+  end
+end
+
+# A couple of staff-only veterans (no combat assignment)
+2.times do
+  enlist_date = Date.current - rand(1_500..2_900)
+  user = create_user!(rank_abbr: "SSgt.", enlist_date:, game: "dh")
+  assign!(user, training_platoon_for(enlist_date, :dh), "Recruit",
+    enlist_date + 2, enlist_date + BCT_DAYS)
+  assign!(user, Unit.find_by!(abbr: "Adj"), "Senior Adjutant Clerk", Date.current - rand(300..900))
+  plan_promotions!(user, "SSgt.", enlist_date, Date.current - rand(200..400))
+end
+
+# Server admins hold broad permissions via the Temporary Admins unit
+admins = Unit.find_by!(abbr: "Admins")
+@member_profiles.sample(2).each do |profile|
+  assign!(profile[:user], admins, "Server Admin", Date.current - rand(100..600))
+end
+
+# Squad-leadership candidates: members working toward NCO rank
+slt = Unit.find_by!(abbr: "SLT")
+@member_profiles
+  .select { |p| p[:user].rank.abbr == "PFC" && p[:career_end].nil? }
+  .sample(8)
+  .each { |p| assign!(p[:user], slt, "SLT Candidate", Date.current - rand(10..90)) }
+
+# Cadets currently in basic training
+Unit.active.training.where("abbr LIKE ?", "TP %").find_each do |tp|
+  enlist_month = TRAINING_PLATOONS.find { |t| t[:unit] == tp }[:month]
+  rand(4..8).times do
+    enlist_date = [enlist_month - rand(3..10), Date.current - 3].min
+    user = create_user!(rank_abbr: "Rec.", enlist_date:, game: tp.game)
+    assign!(user, tp, "Recruit", [enlist_month, Date.current].min)
+    @member_profiles.last[:cadet] = true
+  end
+end
+
+# Recruits awaiting a training platoon
+recruit_pool = Unit.find_by!(abbr: "Recruit Pool")
+2.times do
+  enlist_date = Date.current - rand(3..12)
+  user = create_user!(rank_abbr: "Rec.", enlist_date:, game: "squad")
+  assign!(user, recruit_pool, "Recruit", enlist_date + 1)
+  @member_profiles.last[:cadet] = true
+end
+
+puts "   active roster: #{User.count} users"
+
+# --- Historical members: the 3-year enlistment funnel ---------------------
+
+1_100.times do
+  enlist_date = Date.current - rand(45..(36 * 30))
+  game = TRAINING_PLATOONS.select { |tp| tp[:month] == enlist_date.beginning_of_month }
+    .map { |tp| tp[:game] }.sample || "squad"
+  user = create_user!(rank_abbr: "Rec.", enlist_date:, game:)
+  profile = @member_profiles.last
+
+  status_roll = rand
+  if status_roll < 0.21
+    profile[:enlist_status] = :withdrawn
+    next
+  elsif status_roll < 0.31
+    profile[:enlist_status] = :denied
+    next
+  end
+
+  tp = training_platoon_for(enlist_date, game)
+  if status_roll < 0.48 # went AWOL during basic training
+    profile[:enlist_status] = :awol
+    assign!(user, tp, "Recruit", enlist_date + 2, enlist_date + rand(5..20))
+    next
+  end
+
+  # Accepted. ~30% wash out of BCT; the rest graduate into a squad and
+  # churn out on the production curve (median ended assignment ~44 days,
+  # long tail out to ~1.5 years), ending in a discharge.
+  if rand < 0.3
+    assign!(user, tp, "Recruit", enlist_date + 2, enlist_date + rand(10..27))
+    profile[:graduated] = false
+    next
+  end
+
+  assign!(user, tp, "Recruit", enlist_date + 2, enlist_date + BCT_DAYS)
+  career_days = case rand
+  when 0..0.4 then rand(14..60)
+  when 0.4..0.7 then rand(60..180)
+  when 0.7..0.9 then rand(180..540)
+  else rand(540..1_200)
+  end
+  squad_start = enlist_date + BCT_DAYS
+  career_end = [squad_start + career_days, Date.current - 7].min
+  squad = active_squads.sample
+  rank = (career_days > 700) ? "Cpl." : ((career_days > 240) ? "PFC" : "Pvt.")
+  assign!(user, squad, squad_member_positions.sample, squad_start, career_end)
+  plan_promotions!(user, rank, enlist_date, career_end)
+  user.update!(rank: RANKS.fetch(rank))
+  profile[:career_end] = career_end
+
+  discharge_type = if career_days < 180
+    (rand < 0.75) ? :general : ((rand < 0.97) ? :honorable : :dishonorable)
+  else
+    (rand < 0.7) ? :honorable : :general
+  end
+  Discharge.create!(user:, date: career_end, type: discharge_type,
+    reason: (discharge_type == :honorable) ?
+      "Discharged at own request after service in good standing." :
+      Faker::Lorem.sentence(word_count: 8),
+    was_reversed: false, forum_id: forum_for(career_end),
+    topic_id: fake_topic_id.to_s)
+end
+
+Promotion.insert_all(@promotion_rows)
+puts "   users: #{User.count}, assignments: #{Assignment.count}, promotions: #{@promotion_rows.size}"
+
+# --- Enlistment papers for everyone ----------------------------------------
+
+liaisons = Unit.find_by!(abbr: "LH").users.distinct.to_a
+veteran_recruiters = @member_profiles
+  .select { |p| p[:career_end].nil? && !p[:cadet] && p[:enlist_date] < 1.year.ago.to_date }
+  .map { |p| p[:user] }
+  .sample(30)
+recruit_sources = ["", "", "Google", "YouTube", "Reddit", "A friend", "Steam forums"]
+
+@member_profiles.each do |profile|
+  user = profile[:user]
+  date = profile[:enlist_date]
+  recruiter_user = (rand < 0.5) ? veteran_recruiters.sample : nil
+  tp = if profile[:enlist_status] == :accepted && user.assignments.any?
+    user.assignments.joins(:unit).merge(Unit.training).first&.unit
+  end
+
+  enlistment = Enlistment.create!(
+    user:, date:, status: profile[:enlist_status],
+    unit: tp, liaison: liaisons.sample,
+    age: rand(15..32).to_s,
+    timezone: %i[est est est gmt gmt pst any_timezone].sample,
+    game: profile[:game].to_s,
+    ingame_name: Faker::Internet.username(specifier: 5..12),
+    steam_name: (rand < 0.6) ? Faker::Internet.username(specifier: 5..12) : nil,
+    steam_id: user.steam_id,
+    email: user.email.first(60),
+    discord_username: (rand < 0.7) ? Faker::Internet.username(specifier: 4..20) : nil,
+    experience: Faker::Lorem.paragraph(sentence_count: 2),
+    comments: (rand < 0.4) ? Faker::Lorem.sentence : "",
+    recruiter: recruiter_user ? recruiter_user.short_name : recruit_sources.sample,
+    recruiter_user:,
+    forum_id: forum_for(date), topic_id: fake_topic_id
+  )
+  profile[:enlistment] = enlistment
+end
+puts "   enlistments: #{Enlistment.count}"
+
+# A few pending enlistments to exercise the processing workflow
+3.times do
+  enlist_date = Date.current - rand(0..5)
+  user = create_user!(rank_abbr: "Rec.", enlist_date:, game: "squad")
+  profile = @member_profiles.pop # keep pending users out of the extras passes
+  Enlistment.create!(
+    user:, date: enlist_date, status: :pending,
+    liaison: liaisons.sample, age: rand(15..32).to_s,
+    timezone: :est, game: "squad",
+    ingame_name: Faker::Internet.username(specifier: 5..12),
+    steam_id: user.steam_id, email: user.email.first(60),
+    discord_username: Faker::Internet.username(specifier: 4..20),
+    experience: Faker::Lorem.paragraph(sentence_count: 2),
+    comments: "", recruiter: recruit_sources.sample,
+    forum_id: "Discourse", topic_id: fake_topic_id
+  )
+end
+
+# --- Awards, qualifications and other per-member extras --------------------
+
+award_pool = Award.where(active: true).to_a.shuffle
+# Zipf-ish weights: a handful of awards account for most awardings
+award_weights = award_pool.each_with_index.map { |_, i| 1.0 / (i + 1) }
+award_weight_total = award_weights.sum
+
+def weighted_award(pool, weights, total)
+  roll = rand * total
+  pool.each_with_index do |award, i|
+    roll -= weights[i]
+    return award if roll <= 0
+  end
+  pool.last
+end
+
+award_rows = []
+qual_rows = []
+standards_by_game = AITStandard.all.group_by(&:game)
+instructors = Unit.find_by!(abbr: "Ord").users.distinct.to_a
+
+@member_profiles.each do |profile|
+  next unless profile[:graduated] && !profile[:cadet]
+  user = profile[:user]
+  service_start = profile[:enlist_date] + BCT_DAYS
+  service_end = profile[:career_end] || Date.current
+  service_days = (service_end - service_start).to_i
+  next if service_days <= 0
+
+  # Awardings: ~2 for BCT graduation, then steady accrual (active-member
+  # median in production is ~19)
+  count = 2 + [(service_days / 60.0 * rand(0.5..1.5)).round, 40].min
+  count.times do
+    date = service_start + rand(0..service_days)
+    award_rows << {member_id: user.id, date:,
+                   award_id: weighted_award(award_pool, award_weights, award_weight_total).id,
+                   forum_id: forum_for(date), topic_id: fake_topic_id}
+  end
+
+  # AIT qualifications in the member's game (median ~38 for active members)
+  standards = standards_by_game[profile[:game].to_s] || []
+  qual_count = [3 + (service_days / 30.0 * rand(0.8..1.6)).round, standards.size, 60].min
+  standards.sample(qual_count).each do |standard|
+    qual_rows << {member_id: user.id, standard_id: standard.id,
+                  date: service_start + rand(0..service_days),
+                  author_member_id: instructors.sample&.id}
+  end
+end
+
+UserAward.insert_all(award_rows)
+qual_rows.each_slice(5_000) { |slice| AITQualification.insert_all(slice) }
+puts "   awardings: #{award_rows.size}, qualifications: #{qual_rows.size}"
+
+active_profiles = @member_profiles.select { |p| p[:career_end].nil? && !p[:cadet] }
+
+# Extended LOAs (~200/year in production, mostly in the past)
+active_profiles.sample(active_profiles.size / 6).each do |profile|
+  rand(1..2).times do
+    start_date = profile[:enlist_date] + BCT_DAYS + rand(30..600)
+    next if start_date >= Date.current
+    end_date = start_date + rand(7..45)
+    ExtendedLOA.create!(user: profile[:user], start_date:, end_date:,
+      return_date: (end_date < Date.current && rand < 0.8) ? end_date + rand(0..5) : nil,
+      reason: Faker::Lorem.sentence(word_count: 6),
+      availability: (rand < 0.5) ? "Reachable on Discord" : nil)
+  end
+end
+# ...and a few currently on leave
+active_profiles.sample(3).each do |profile|
+  ExtendedLOA.create!(user: profile[:user],
+    start_date: Date.current - rand(3..10), end_date: Date.current + rand(7..30),
+    reason: Faker::Lorem.sentence(word_count: 6), availability: "Limited")
+end
+
+# Weapon passes: recruitment rewards and donor passes
+finance_authors = Unit.find_by!(abbr: "Fin").users.distinct.to_a
+Enlistment.accepted.where.not(recruiter_member_id: nil).limit(25).find_each do |enlistment|
+  Pass.create!(user: enlistment.recruiter_user, recruit: enlistment.user,
+    author: finance_authors.sample, type: :recruitment,
+    start_date: enlistment.date, end_date: enlistment.date + 30,
+    reason: "Pass for recruiting #{enlistment.user.last_name}")
+end
+active_profiles.sample(12).each do |profile|
+  start_date = Date.current - rand(0..60)
+  Pass.create!(user: profile[:user], author: finance_authors.sample,
+    type: :recurring_donation, start_date:, end_date: start_date + 90,
+    reason: "Soldier has made a recurring donation.")
+end
+
+# Admin notes on members (rare; various visibility levels)
+note_authors = (Unit.find_by!(abbr: "MP").users.distinct.to_a + liaisons).uniq
+note_accesses = ["Members Only", "Squad Level", "Platoon Level",
+  "Company Level", "Battalion HQ", "Military Police", "Lighthouse"]
+note_rows = @member_profiles.sample(60).map do |profile|
+  date = Faker::Date.between(from: profile[:enlist_date], to: Date.current)
+  {member_id: profile[:user].id, author_member_id: note_authors.sample.id,
+   date_add: date, date_mod: date, access: note_accesses.sample,
+   subject: Faker::Lorem.sentence(word_count: 4).delete_suffix("."),
+   content: Faker::Lorem.paragraph(sentence_count: 3)}
+end
+Note.insert_all(note_rows)
+
+# Demerits are rare (~10/year in production)
+mp_authors = Unit.find_by!(abbr: "MP").users.distinct.to_a
+@member_profiles.sample(12).each do |profile|
+  date = Faker::Date.between(from: profile[:enlist_date], to: Date.current)
+  Demerit.create!(user: profile[:user], author: mp_authors.sample,
+    date:, reason: "AWOL from mandatory #{["squad drill", "platoon drill", "BCT session"].sample}",
+    forum_id: forum_for(date), topic_id: fake_topic_id)
+end
+
+# Finance ledger: monthly hosting invoices out, donations in
+36.downto(1) do |months_ago|
+  month = months_ago.months.ago.to_date.beginning_of_month
+  [["game_servers", 60], ["digital_ocean", 24], ["google", 12]].each do |vendor, amount|
+    FinanceRecord.create!(date: month + 3, vendor:, amount_paid: amount,
+      notes: "Monthly invoice")
+  end
+  rand(4..10).times do
+    amount = [5, 10, 10, 15, 20, 25].sample
+    FinanceRecord.create!(date: Faker::Date.between(from: month, to: month.end_of_month),
+      vendor: :notapplicable, member_id: @member_profiles.sample[:user].id,
+      amount_received: amount, fee: (0.3 + amount * 0.029).round(2),
+      notes: "Donation")
+  end
+end
+
+# Reserved surnames of notable former members
+@member_profiles
+  .select { |p| p[:career_end].present? }
+  .sample(4)
+  .each { |p| RestrictedName.create!(user: p[:user], name: p[:user].last_name) }
+
+puts "   eloas: #{ExtendedLOA.count}, passes: #{Pass.count}, notes: #{Note.count}, " \
+     "demerits: #{Demerit.count}, finances: #{FinanceRecord.count}"

--- a/db/seeds/05_events.rb
+++ b/db/seeds/05_events.rb
@@ -1,0 +1,153 @@
+# Three years of events and attendance plus two weeks of upcoming events.
+# Cadence mirrors production: each squad drills twice a week (~100
+# events/year), platoons/companies/battalions at wider intervals, and
+# training platoons run BCT sessions during their month. Attendance outcome
+# rates match production: ~63% attended, ~20% excused, ~17% absent.
+
+HISTORY_WEEKS = 156
+FUTURE_DAYS = 14
+
+# [member_id, start, end] intervals per unit, for computing who was expected
+# at an event on a given date (includes historical members' stints)
+assignments_by_unit = Hash.new { |h, k| h[k] = [] }
+Assignment.pluck(:unit_id, :member_id, :start_date, :end_date).each do |unit_id, member_id, start_date, end_date|
+  assignments_by_unit[unit_id] << [member_id, start_date, end_date]
+end
+leaders_by_unit = Hash.new { |h, k| h[k] = [] }
+Assignment.joins(:position).where(positions: {access_level: 10})
+  .pluck(:unit_id, :member_id, :start_date, :end_date)
+  .each do |unit_id, member_id, start_date, end_date|
+    leaders_by_unit[unit_id] << [member_id, start_date, end_date]
+  end
+
+def members_on(intervals_by_unit, unit_ids, date)
+  unit_ids.flat_map do |unit_id|
+    intervals_by_unit[unit_id]
+      .select { |_, start_date, end_date| start_date && start_date <= date && (end_date.nil? || end_date > date) }
+      .map(&:first)
+  end.uniq
+end
+
+active_servers = Server.where(active: true).to_a
+
+def pick_server(active_servers, game, preferred_abbrs)
+  candidates = game ? active_servers.select { |s| s.game == game } : active_servers
+  candidates = active_servers if candidates.empty?
+  preferred_abbrs.each do |abbr|
+    match = candidates.find { |s| s.abbr == abbr }
+    return match if match
+  end
+  candidates.sample
+end
+
+@event_id = 0
+@event_rows = []
+@attendance_rows = []
+
+def seed_event!(unit:, type:, date:, hour_utc:, time_zone:, server:,
+  roster:, leaders:, mandatory: true)
+  starts_at = Time.utc(date.year, date.month, date.day, hour_utc)
+  past = starts_at < Time.current
+  reporter_id = leaders.sample || roster.sample
+  has_report = past && rand < 0.85
+
+  @event_rows << {
+    id: (@event_id += 1),
+    datetime: starts_at.in_time_zone("Eastern Time (US & Canada)").strftime("%F %R"),
+    unit_id: unit.id, title: nil, type:, mandatory:,
+    server: nil, server_id: server.id,
+    report: has_report ? Faker::Lorem.paragraph(sentence_count: rand(2..5)) : nil,
+    reporter_member_id: has_report ? reporter_id : nil,
+    report_posting_date: has_report ? starts_at + rand(6..30).hours : nil,
+    report_edit_date: nil,
+    starts_at:, time_zone:
+  }
+  return unless past
+
+  roster.each do |member_id|
+    attended = rand < 0.63
+    @attendance_rows << {event_id: @event_id, member_id:, attended:,
+                         excused: !attended && rand < 0.55}
+  end
+end
+
+# Weekly drill schedule per squad, staggered so squads don't all drill on the
+# same nights. GMT squads drill at European-friendly hours.
+weekday_pairs = [[2, 6], [3, 0], [4, 6], [1, 5]]
+first_week = Date.current.beginning_of_week - HISTORY_WEEKS.weeks
+horizon = Date.current + FUTURE_DAYS
+
+Unit.active.combat.where("name LIKE ?", "%Squad%").order(:abbr).each_with_index do |squad, i|
+  hour_utc = squad.gmt? ? 19 : 1
+  time_zone = squad.gmt? ? "London" : "Eastern Time (US & Canada)"
+  server = pick_server(active_servers, squad.game, %w[sq sqd plt co])
+  roster_units = [squad.id]
+
+  (0..HISTORY_WEEKS + 2).each do |week|
+    week_start = first_week + week.weeks
+    weekday_pairs[i % weekday_pairs.size].each do |wday|
+      date = week_start + ((wday - week_start.wday) % 7)
+      next if date > horizon
+      seed_event!(unit: squad, type: "Squad Drills", date:, hour_utc:,
+        time_zone:, server:,
+        roster: members_on(assignments_by_unit, roster_units, date),
+        leaders: members_on(leaders_by_unit, roster_units, date))
+    end
+  end
+end
+
+# Platoon drills every 4 weeks, company drills every 6, battalion quarterly
+{"%P_ HQ" => ["Platoon Drills", 4, %w[plt co]],
+ "%Co. HQ" => ["Company Drills", 6, %w[co bn]],
+ "%Bn. HQ" => ["Battalion Drills", 13, %w[bn co]]}.each do |pattern, (type, cadence_weeks, server_abbrs)|
+  Unit.active.combat.where("abbr LIKE ?", pattern).each_with_index do |unit, i|
+    subtree_ids = unit.subtree_ids
+    server = pick_server(active_servers, unit.game, server_abbrs)
+    week = i % cadence_weeks # stagger
+    while week <= HISTORY_WEEKS + 2
+      date = first_week + week.weeks + 5 # Saturdays
+      week += cadence_weeks
+      next if date > horizon
+      seed_event!(unit:, type:, date:, hour_utc: 20,
+        time_zone: "Eastern Time (US & Canada)", server:,
+        roster: members_on(assignments_by_unit, subtree_ids, date),
+        leaders: members_on(leaders_by_unit, subtree_ids, date))
+    end
+  end
+end
+
+# Occasional non-mandatory public scrimmages at company level
+Unit.active.combat.where("abbr LIKE ?", "%Co. HQ").each do |company|
+  subtree_ids = company.subtree_ids
+  server = pick_server(active_servers, company.game, %w[pub eu co])
+  (0..HISTORY_WEEKS).step(10) do |week|
+    date = first_week + week.weeks + 6
+    seed_event!(unit: company, type: "Public Scrimmage", date:, hour_utc: 21,
+      time_zone: "Eastern Time (US & Canada)", server:, mandatory: false,
+      roster: members_on(assignments_by_unit, subtree_ids, date).sample(30),
+      leaders: members_on(leaders_by_unit, subtree_ids, date))
+  end
+end
+
+# Basic Combat Training: three sessions a week during each platoon's month
+TRAINING_PLATOONS.each do |tp|
+  unit = tp[:unit]
+  server = pick_server(active_servers, unit.game, %w[bct plt co])
+  roster_units = [unit.id]
+  (0..3).each do |week|
+    [1, 3, 5].each do |offset|
+      date = tp[:month].beginning_of_week + week.weeks + offset
+      next if date > horizon
+      roster = members_on(assignments_by_unit, roster_units, date)
+      next if roster.empty?
+      seed_event!(unit:, type: "Basic Combat Training", date:, hour_utc: 1,
+        time_zone: "Eastern Time (US & Canada)", server:,
+        roster:, leaders: [])
+    end
+  end
+end
+
+@event_rows.each_slice(2_000) { |slice| Event.insert_all(slice) }
+@attendance_rows.each_slice(5_000) { |slice| AttendanceRecord.insert_all(slice) }
+
+puts "   events: #{@event_rows.size}, attendance records: #{@attendance_rows.size}"

--- a/db/seeds/data/abilities.yml
+++ b/db/seeds/data/abilities.yml
@@ -1,0 +1,276 @@
+- id: 1
+  name: "Edit Profile"
+  abbr: "profile_edit"
+  description: "<p>Edit a member's profile</p>"
+- id: 2
+  name: "Promote"
+  abbr: "promotion_add"
+  description: "Add a promotion to a member's record and change the member's rank to it if applicable"
+- id: 3
+  name: "Award"
+  abbr: "award_add"
+  description: "Give a member an award"
+- id: 4
+  name: "View Any Profile"
+  abbr: "profile_view_any"
+  description: "View any member's profile"
+- id: 5
+  name: "Delete Promotion"
+  abbr: "promotion_delete"
+  description: "Delete a member's promotion and demote them if applicable"
+- id: 6
+  name: "Give Award"
+  abbr: "awarding_add"
+  description: "Give a member an award"
+- id: 7
+  name: "Delete Awarding"
+  abbr: "awarding_delete"
+  description: "Remove an award from a member's record"
+- id: 8
+  name: "Give Qualification"
+  abbr: "qualification_add"
+  description: "Give qualification to a member"
+- id: 9
+  name: "Delete Qualification"
+  abbr: "qualification_delete"
+  description: "Delete a qualification from a member's service record"
+- id: 10
+  name: "Promote Any Member"
+  abbr: "promotion_add_any"
+  description: ""
+- id: 11
+  name: "Delete Any Promotion"
+  abbr: "promotion_delete_any"
+  description: ""
+- id: 12
+  name: "Give Award to Any Member"
+  abbr: "awarding_add_any"
+  description: ""
+- id: 13
+  name: "Delete Any Awarding"
+  abbr: "awarding_delete_any"
+  description: ""
+- id: 14
+  name: "Give Qualification to Any Member"
+  abbr: "qualification_add_any"
+  description: ""
+- id: 15
+  name: "Delete Any Qualification"
+  abbr: "qualification_delete_any"
+  description: ""
+- id: 16
+  name: "Assign Member"
+  abbr: "assignment_add"
+  description: ""
+- id: 17
+  name: "Assign Any Member"
+  abbr: "assignment_add_any"
+  description: ""
+- id: 18
+  name: "Delete Assignment"
+  abbr: "assignment_delete"
+  description: ""
+- id: 19
+  name: "Delete Any Assignment"
+  abbr: "assignment_delete_any"
+  description: ""
+- id: 20
+  name: "Add Unit"
+  abbr: "unit_add"
+  description: ""
+- id: 21
+  name: "Discharge Any Member"
+  abbr: "discharge_add_any"
+  description: ""
+- id: 22
+  name: "Admin"
+  abbr: "admin"
+  description: "<p>Full access, including admin panel</p>"
+- id: 23
+  name: "Post Event AAR"
+  abbr: "event_aar"
+  description: ""
+- id: 24
+  name: "Process Any Enlistment"
+  abbr: "enlistment_process_any"
+  description: ""
+- id: 25
+  name: "Edit Any Profile"
+  abbr: "profile_edit_any"
+  description: "Edit any member's profile"
+- id: 26
+  name: "Modify Any Enlistment"
+  abbr: "enlistment_edit_any"
+  description: "Modify any member's enlistment"
+- id: 27
+  name: "View Any Event"
+  abbr: "event_view_any"
+  description: ""
+- id: 28
+  name: "Post Any Event AAR"
+  abbr: "event_aar_any"
+  description: ""
+- id: 29
+  name: "View Any Unit Statistics"
+  abbr: "unit_stats_any"
+  description: ""
+- id: 30
+  name: "View Finances"
+  abbr: "finance_view_any"
+  description: ""
+- id: 31
+  name: "Assign Any Enlistment"
+  abbr: "enlistment_assign_any"
+  description: "Assign an enlistment to a liaison"
+- id: 32
+  name: "Admin Events"
+  abbr: "admin-events"
+  description: ""
+- id: 33
+  name: "Admin Promotions"
+  abbr: "admin-promotions"
+  description: ""
+- id: 34
+  name: "Admin Awardings"
+  abbr: "admin-awardings"
+  description: ""
+- id: 35
+  name: "Admin Discharges"
+  abbr: "admin-discharges"
+  description: ""
+- id: 36
+  name: "Admin Demerits"
+  abbr: "admin-demerits"
+  description: ""
+- id: 37
+  name: "Admin Finances"
+  abbr: "admin-finances"
+  description: ""
+- id: 38
+  name: "Admin Units"
+  abbr: "admin-units"
+  description: ""
+- id: 39
+  name: "Admin Ban Log"
+  abbr: "admin-banlog"
+  description: ""
+- id: 40
+  name: "View Any Extended LOA"
+  abbr: "eloa_view_any"
+  description: ""
+- id: 41
+  name: "Admin Extended LOAs"
+  abbr: "admin-eloas"
+  description: ""
+- id: 42
+  name: "Discharge Member"
+  abbr: "discharge_add"
+  description: ""
+- id: 43
+  name: "View Any Demerit"
+  abbr: "demerit_view_any"
+  description: ""
+- id: 44
+  name: "Add Event"
+  abbr: "event_add"
+  description: ""
+- id: 45
+  name: "Add Any Event"
+  abbr: "event_add_any"
+  description: ""
+- id: 46
+  name: "Admin Attendance"
+  abbr: "admin-attendance"
+  description: "API Admin access to Attendance"
+- id: 47
+  name: "ELOA Add"
+  abbr: "eloa_add"
+  description: ""
+- id: 48
+  name: "ELOA Add Any"
+  abbr: "eloa_add_any"
+  description: ""
+- id: 49
+  name: "Admin Enlistments"
+  abbr: "admin-enlistments"
+  description: "API admin for Enlistments"
+- id: 50
+  name: "View notes"
+  abbr: "note_view_any"
+  description: ""
+- id: 51
+  name: "View notes for all levels"
+  abbr: "note_view_all"
+  description: ""
+- id: 52
+  name: "View notes for MP Level"
+  abbr: "note_view_mp"
+  description: ""
+- id: 53
+  name: "View notes for Company Level"
+  abbr: "note_view_co"
+  description: ""
+- id: 54
+  name: "View notes for Platoon Level"
+  abbr: "note_view_pl"
+  description: ""
+- id: 55
+  name: "View notes for Squad Level"
+  abbr: "note_view_sq"
+  description: ""
+- id: 56
+  name: "View notes for Lighthouse"
+  abbr: "note_view_lh"
+  description: ""
+- id: 57
+  name: "Admin Notes"
+  abbr: "admin-notes"
+  description: ""
+- id: 58
+  name: "Admin Weapon Passes"
+  abbr: "admin-weapon_passes"
+  description: ""
+- id: 59
+  name: "View Ban Logs"
+  abbr: "banlog_view_any"
+  description: "View banlogs on front end."
+- id: 60
+  name: "Add/Edit Any Banlog"
+  abbr: "banlog_edit_any"
+  description: ""
+- id: 61
+  name: "Add demerit"
+  abbr: "demerit_add"
+  description: "Add demerit to members of my unit and all its children"
+- id: 62
+  name: "Add any demerit"
+  abbr: "demerit_add_any"
+  description: "Add demerit to any member"
+- id: 63
+  name: "View Any Qualification"
+  abbr: "qualification_view_any"
+  description: "View any qualification"
+- id: 64
+  name: "View Weapon Passes"
+  abbr: "pass_view_any"
+  description: ""
+- id: 65
+  name: "Add/Edit Any Weapon Pass"
+  abbr: "pass_edit_any"
+  description: ""
+- id: 66
+  name: "Add/Edit Weapon Pass"
+  abbr: "pass_edit"
+  description: "Add/Edit Weapon Pass for any member of this unit and ones below"
+- id: 67
+  name: "Add Finance Record"
+  abbr: "finance_add"
+  description: null
+- id: 68
+  name: "Manage"
+  abbr: "manage"
+  description: "Access the /manage/ section of the site"
+- id: 69
+  name: "View Any Restricted Name"
+  abbr: "restricted_name_view_any"
+  description: null

--- a/db/seeds/data/ait_standards.yml
+++ b/db/seeds/data/ait_standards.yml
@@ -1,0 +1,5022 @@
+- id: 1
+  weapon: "EIB"
+  game: ""
+  badge: "N/A"
+  description: "General knowledge of common maps and positions via grid and compass"
+  details: null
+- id: 2
+  weapon: "EIB"
+  game: ""
+  badge: "N/A"
+  description: "Proper usage of secondary weapons and standard equipment"
+  details: "Pistols, grenades, etc."
+- id: 3
+  weapon: "EIB"
+  game: ""
+  badge: "N/A"
+  description: "Demonstrates understanding and obedience of orders while maintaining cohesion with their squad"
+  details: null
+- id: 4
+  weapon: "EIB"
+  game: ""
+  badge: "N/A"
+  description: "Effective communication of target locations"
+  details: "Using map grid and o'clock systems. Properly identifies targets; rarely commits teamkills"
+- id: 5
+  weapon: "EIB"
+  game: ""
+  badge: "N/A"
+  description: "Understands how and when to provide covering fire"
+  details: null
+- id: 6
+  weapon: "EIB"
+  game: ""
+  badge: "N/A"
+  description: "Ability to adjust stance appropriately to achieve effective firing position"
+  details: "Knows the time and place for leaning, crouching, and going prone"
+- id: 7
+  weapon: "EIB"
+  game: ""
+  badge: "N/A"
+  description: "Timely and safe reloading"
+  details: "Knows when, during combat, to take the time to reload, and maintains enough cover while reloading"
+- id: 8
+  weapon: "EIB"
+  game: ""
+  badge: "N/A"
+  description: "Discipline to break contact and/or flank"
+  details: "This is done when a strong opposition is met. Instead of staying put and hoping to get the first hit, the soldier should have the discipline to break contact and surprise the enemy from another location, or even regroup with another section of his team."
+- id: 9
+  weapon: "EIB"
+  game: ""
+  badge: "N/A"
+  description: "Automatically relocates after enemy knows his position"
+  details: "It is easy for a soldier to get caught up in racking up kills when he finds a good position, but word will quickly get around the enemy team and unless he relocates he will be taken out."
+- id: 11
+  weapon: "EIB"
+  game: ""
+  badge: "N/A"
+  description: "Knowledge of and able to perform actions not intended by game design"
+  details: "This includes all engine tricks and exploits"
+- id: 12
+  weapon: "EIB"
+  game: ""
+  badge: "N/A"
+  description: "Able to use map/scenario specific equipment when necessary"
+  details: "This includes weapon emplacements, vehicles, or any map specific usables"
+- id: 13
+  weapon: "EIB"
+  game: ""
+  badge: "N/A"
+  description: "Gathers accurate player teams and locations based on sounds"
+  details: null
+- id: 14
+  weapon: "EIB"
+  game: ""
+  badge: "N/A"
+  description: "Has earned an Arms Qualification badge with a weapon"
+  details: null
+- id: 15
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows general knowledge of all rifles"
+  details: "How many shots they hold, how much damage they do, where to aim with them"
+- id: 16
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Marksman"
+  description: "Aims for target's chest"
+  details: ""
+- id: 17
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Marksman"
+  description: "Knows when and how to effectively use melee"
+  details: null
+- id: 18
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Marksman"
+  description: "Does not get caught stuck to the bolt"
+  details: null
+- id: 19
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Marksman"
+  description: "Keeps track of the number of rounds left"
+  details: ""
+- id: 20
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Marksman"
+  description: "Can differentiate gameplay style based on rifle"
+  details: ""
+- id: 22
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control with weapon"
+  details: ""
+- id: 23
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Accurate at all ranges with iron sights"
+  details: null
+- id: 24
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Accurate at short and medium ranges when firing from the hip"
+  details: ""
+- id: 26
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: "Leading a moving target refers to firing slightly in front of where they are moving so that by the time the bullet reaches them they will be in that position"
+- id: 27
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Properly uses cover to maintain an effective defensive position"
+  details: null
+- id: 28
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Implements important gameplay techniques into everyday play"
+  details: null
+- id: 29
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 30
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: "Soldier is defeated by lack of knowledge, not lack of skill"
+- id: 31
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 32
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 33
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows general knowledge of all automatic rifles"
+  details: "How many shots they hold, how much damage they do, where to aim with them"
+- id: 34
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands recoil and the use of burst to control it"
+  details: ""
+- id: 35
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands concepts of and shows basic skills of building clearing"
+  details: ""
+- id: 36
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands the idea of being a supporting element"
+  details: ""
+- id: 37
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands the effectiveness of pre-firing common positions"
+  details: ""
+- id: 38
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Marksman"
+  description: "Can locate effective defensive firing positions"
+  details: ""
+- id: 39
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control with weapon"
+  details: ""
+- id: 40
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to fire accurately and control recoil at medium to long range with iron sights"
+  details: ""
+- id: 41
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to fire accurately and control recoil at medium to long range with weapon deployed"
+  details: ""
+- id: 42
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to fire accurately and control recoil at close and medium range while firing from the hip"
+  details: ""
+- id: 43
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Understands when to use single-shot and when to use burst fire"
+  details: ""
+- id: 44
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: ""
+- id: 46
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to effectively eliminate targets while on-the-move to destination"
+  details: ""
+- id: 47
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Frequently able to clear a building single-handedly"
+  details: ""
+- id: 50
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: ""
+- id: 51
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: "Soldier is defeated by lack of knowledge, not lack of skill"
+- id: 52
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: ""
+- id: 53
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: ""
+- id: 54
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Expert"
+  description: "Can instruct AIT users in the use of the automatic rifle"
+  details: ""
+- id: 55
+  weapon: "Automatic Rifle"
+  game: "DH"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: ""
+- id: 56
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows general knowledge of all machine guns"
+  details: "How many shots they hold, how much damage they do, where to aim with them"
+- id: 57
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Can effectively provide suppressive MG fire"
+  details: ""
+- id: 58
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands how and when to advance to support team"
+  details: null
+- id: 59
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "General understanding of timing involved in deploying/un-deploying"
+  details: null
+- id: 60
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Show an understanding of how to preserve MG barrels"
+  details: null
+- id: 61
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Frequently able to hold off an entire flank from an enclosed area of a map"
+  details: null
+- id: 62
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Deploys in areas providing as little visibility to the enemy as possible"
+  details: null
+- id: 63
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Frequently asks for support from another soldier to cover the flanks"
+  details: null
+- id: 64
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands what structures can be used for support"
+  details: ""
+- id: 65
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to locate effective vantage points and positions automatically"
+  details: null
+- id: 66
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to utilize a spotter to find targets"
+  details: null
+- id: 67
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Frequently able to hold off an entire flank from an unenclosed area of a map"
+  details: null
+- id: 68
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to effectively communicate with teammates to locate and eliminate distant targets"
+  details: null
+- id: 69
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to eliminate 3-5 targets before being spotted"
+  details: null
+- id: 70
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: null
+- id: 71
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 72
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: "Soldier is defeated by lack of knowledge, not lack of skill"
+- id: 73
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 74
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 75
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 76
+  weapon: "Armor"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows general knowledge of all tanks"
+  details: null
+- id: 77
+  weapon: "Armor"
+  game: "DH"
+  badge: "Marksman"
+  description: "Uses common communication techniques"
+  details: null
+- id: 78
+  weapon: "Armor"
+  game: "DH"
+  badge: "Marksman"
+  description: "Displays mastery over the o'clock system"
+  details: null
+- id: 79
+  weapon: "Armor"
+  game: "DH"
+  badge: "Marksman"
+  description: "Scans FOV for enemy, prioritizing anti-tank targets"
+  details: null
+- id: 80
+  weapon: "Armor"
+  game: "DH"
+  badge: "Marksman"
+  description: "Can identify enemy vehicle type"
+  details: null
+- id: 81
+  weapon: "Armor"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands flex and arc"
+  details: "Flex meaning knowing how to adjust fire horizontally to 'lead' moving targets; Arc meaning knowing how to adjust fire vertically to compensate for range"
+- id: 82
+  weapon: "Armor"
+  game: "DH"
+  badge: "Marksman"
+  description: "Knowledge of the BOW MG"
+  details: "5-7 second bursts, turning tank to face threat"
+- id: 83
+  weapon: "Armor"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Understands the different shell types"
+  details: "Advantages/disadvantages"
+- id: 84
+  weapon: "Armor"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Effective gunnery at long ranges"
+  details: null
+- id: 85
+  weapon: "Armor"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to work with other tanks"
+  details: null
+- id: 86
+  weapon: "Armor"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Effective as a one-man-tank when necessary"
+  details: null
+- id: 87
+  weapon: "Armor"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Logically averts obstacles within scope of orders"
+  details: null
+- id: 88
+  weapon: "Armor"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Understands how left/right adjustment of vehicle affects commander's aim"
+  details: null
+- id: 89
+  weapon: "Armor"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Knowledge of obstacles and what a tank can traverse"
+  details: "Ditches and bushes"
+- id: 90
+  weapon: "Armor"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Knows how to angle the tank to provide the most protection"
+  details: "Both when idle and when moving"
+- id: 91
+  weapon: "Armor"
+  game: "DH"
+  badge: "Expert"
+  description: "Able to identify the best tanking positions"
+  details: ""
+- id: 92
+  weapon: "Armor"
+  game: "DH"
+  badge: "Expert"
+  description: "Effective gunnery on the move"
+  details: null
+- id: 93
+  weapon: "Armor"
+  game: "DH"
+  badge: "Expert"
+  description: "Understands the different arc for different round velocities"
+  details: "Including moving targets"
+- id: 94
+  weapon: "Armor"
+  game: "DH"
+  badge: "Expert"
+  description: "Effective use of blind spots and dead ground"
+  details: "Areas where you can get to the enemy without them seeing you"
+- id: 95
+  weapon: "Armor"
+  game: "DH"
+  badge: "Expert"
+  description: "Knows the soft spots of enemy vehicles"
+  details: null
+- id: 96
+  weapon: "Armor"
+  game: "DH"
+  badge: "Expert"
+  description: "Understands land navigation and infantry interface"
+  details: ""
+- id: 97
+  weapon: "Armor"
+  game: "DH"
+  badge: "Expert"
+  description: "Prioritizes between enemy tanks and enemy infantry"
+  details: null
+- id: 98
+  weapon: "Armor"
+  game: "DH"
+  badge: "Expert"
+  description: "Accurately estimates range/timing to achieve first shot hits"
+  details: "Including moving targets"
+- id: 99
+  weapon: "Armor"
+  game: "DH"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness, crisis management, and aversion to friendly fire"
+  details: ""
+- id: 100
+  weapon: "Armor"
+  game: "DH"
+  badge: "Expert"
+  description: "Can instruct AIT users in the use of the tank"
+  details: ""
+- id: 101
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows general knowledge of all anti-tank weapons"
+  details: "Their range, how much damage they do, where to aim with them"
+- id: 102
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Marksman"
+  description: "Can effectively use secondary weapon assigned to Engineer class"
+  details: null
+- id: 103
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands the basic mechanics behind damaging tanks"
+  details: "Where to aim for best results"
+- id: 104
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows basic knowledge of using the anti-tank for building clearing purposes"
+  details: null
+- id: 105
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands potential friendly fire damage from anti-tank explosion or exhaust"
+  details: null
+- id: 106
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands the idea of being a supporting element"
+  details: null
+- id: 107
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands the timing involved in reloading, deploying, etc."
+  details: null
+- id: 108
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 110
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Accurate with anti-Tank at all ranges"
+  details: null
+- id: 111
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Effectively targets vulnerable areas on tanks"
+  details: null
+- id: 112
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Maintains teamwork with provided supplier for faster rate of fire"
+  details: null
+- id: 113
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Effectively communicates with squad leaders to coordinate fire"
+  details: null
+- id: 114
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Shows knowledge of how to close in and flank around armored vehicles"
+  details: null
+- id: 115
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Can effectively use the anti-tank to clear out fortified & window positions"
+  details: null
+- id: 116
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Indepth understanding of anti-tank splash-damage and anti-infantry tactics"
+  details: null
+- id: 117
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving vehicle"
+  details: null
+- id: 118
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Effectively uses each projectile range on the different anti-tank weapons"
+  details: null
+- id: 119
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Has a vast knowledge of tank statistics "
+  details: "Ammo types, speed, etc."
+- id: 120
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 121
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death "
+  details: "Soldier is defeated by lack of knowledge, not lack of skill"
+- id: 122
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 123
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 124
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 125
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Expert"
+  description: "Can instruct AIT users in the use of the combat engineer class"
+  details: null
+- id: 126
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows general knowledge of all sub-machine guns"
+  details: "How many shots they hold, how much damage they do, where to aim with them"
+- id: 127
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows effectiveness in building clearing"
+  details: null
+- id: 128
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Able to provide effective cover fire with the submachine gun"
+  details: null
+- id: 129
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Able to identify and move into effective spotting positions"
+  details: null
+- id: 130
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Able to effectively relay information gathered from the use of binoculars"
+  details: null
+- id: 131
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands when to use each firing mode"
+  details: null
+- id: 132
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows proper use of smoke grenades to provide cover for teammates"
+  details: null
+- id: 133
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Able to eliminate multiple targets at a time"
+  details: null
+- id: 134
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Keeps track of the number of rounds left"
+  details: null
+- id: 135
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 141
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to fire accurately and control recoil at medium ranges while firing from the hip with sub-machine guns"
+  details: null
+- id: 142
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to fire accurately and control recoil with iron sights at medium range with sub-machine guns"
+  details: null
+- id: 143
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Frequently able to eliminate three or more targets at a time"
+  details: null
+- id: 144
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: null
+- id: 145
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to master short 3-round bursts to conserve ammunition and control recoil"
+  details: null
+- id: 146
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Shows effectiveness in building clearing with no casualties"
+  details: null
+- id: 147
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 148
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: "Soldier is defeated by lack of knowledge, not lack of skill"
+- id: 149
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 150
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 151
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 152
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows general knowledge of all sniper rifles"
+  details: "Their scope, how much damage they do, where to aim with them"
+- id: 153
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Marksman"
+  description: "Can effectively use secondary weapon assigned to Sniper class"
+  details: null
+- id: 154
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Marksman"
+  description: "Able to locate and report high priority target locations accurately"
+  details: null
+- id: 155
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands the importance of maintaining distance from enemies"
+  details: null
+- id: 156
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Marksman"
+  description: "Can effectively stalk and eliminate a target in territory with dense cover"
+  details: null
+- id: 157
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands the importance of fire discipline"
+  details: null
+- id: 158
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 159
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Accurate at short and medium ranges when firing from the hip"
+  details: null
+- id: 160
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Accurate at the longest range with iron sights"
+  details: null
+- id: 161
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: null
+- id: 162
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Ability to move from cover to cover without detection"
+  details: null
+- id: 163
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to evade and escape enemy contact if detected"
+  details: null
+- id: 164
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to articulate and relay enemy classes and positions accurately"
+  details: null
+- id: 165
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Can stalk and eliminate a target in territory with sparse cover"
+  details: null
+- id: 166
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 167
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: "Soldier is defeated by lack of knowledge, not lack of skill"
+- id: 168
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 169
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 191
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 192
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Expert"
+  description: "Can instruct AIT users in the use of the rifle"
+  details: null
+- id: 193
+  weapon: "Rifle"
+  game: "DH"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 194
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 195
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to quickly switch between numerous areas of deployment"
+  details: null
+- id: 196
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Sufficient reflexes between very thin areas"
+  details: null
+- id: 197
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Always on the move; rarely in the same area for long"
+  details: null
+- id: 198
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Expert"
+  description: "Can instruct AIT users in the use of the machine gun"
+  details: null
+- id: 199
+  weapon: "Machine Gun"
+  game: "DH"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 200
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to defend an enclosed space alone"
+  details: null
+- id: 201
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Expert"
+  description: "Can instruct AIT users in the use of the support class"
+  details: null
+- id: 202
+  weapon: "Submachine Gun"
+  game: "DH"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 203
+  weapon: "Combat Engineer"
+  game: "DH"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 204
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 205
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Expert"
+  description: "Can instruct AIT users in the use of the sniper rifle"
+  details: null
+- id: 206
+  weapon: "Sniper"
+  game: "DH"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 207
+  weapon: "Armor"
+  game: "DH"
+  badge: "Marksman"
+  description: "Recognizes situations where firing would give away their position"
+  details: null
+- id: 208
+  weapon: "Armor"
+  game: "DH"
+  badge: "Marksman"
+  description: "Moves tank only when directed"
+  details: null
+- id: 209
+  weapon: "Armor"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 210
+  weapon: "Armor"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Understands to angle the hull to optimize the bow MG arc"
+  details: null
+- id: 211
+  weapon: "Armor"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Can effectively maneuver against an enemy tank"
+  details: null
+- id: 212
+  weapon: "Armor"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Knows what ammunition is used on what target type"
+  details: null
+- id: 213
+  weapon: "Armor"
+  game: "DH"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 214
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands the basics of mortars"
+  details: "This includes basics of aiming, shooting and the differences between the axis and allied mortars"
+- id: 215
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Marksman"
+  description: "Identify and mark a specific target safely as an observer"
+  details: null
+- id: 216
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Marksman"
+  description: "Understands concealment as both operator and observer"
+  details: null
+- id: 218
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Marksman"
+  description: "Properly uses mortar protocol as both operator and observer"
+  details: null
+- id: 219
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 220
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Accurate against a static unmarked target using direct line of sight"
+  details: null
+- id: 221
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Accurate against a static marked target without using direct line of sight"
+  details: null
+- id: 222
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Effectively mark moving targets as observer"
+  details: null
+- id: 223
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Accurate and correct use of mortar smoke"
+  details: "Smokescreens must be placed correctly on the right target and without big gaps between the clouds"
+- id: 224
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Correctly act upon orders for a fire mission as an operator"
+  details: null
+- id: 225
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Flawless communication with mortar squad"
+  details: "No matter if he is using a communication method via teamspeak or in-game chat"
+- id: 226
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Receive a fire request from leadership and correctly assign fire missions for the situation at hand as observer"
+  details: null
+- id: 227
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Read and create custom range tables"
+  details: null
+- id: 228
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Know and utilize various fire missions correctly and efficiently"
+  details: "Includes specific fire missions such as a barrage, wide barrage or a smokescreen"
+- id: 229
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Sharpshooter"
+  description: "Able to work independently of leadership and create and assign proper fire missions as observer"
+  details: null
+- id: 230
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Expert"
+  description: "Coordinate two mortars as a observer"
+  details: null
+- id: 231
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Expert"
+  description: "Work as an operator in tandem with a second operator"
+  details: null
+- id: 232
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Expert"
+  description: "Expertise mortar knowledge of maps"
+  details: "Includes common firing positions, map size and ranges, and various other areas of interest"
+- id: 233
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Expert"
+  description: "Memorize target locations and switch between them without the use of an observer"
+  details: null
+- id: 234
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Expert"
+  description: "Can instruct AIT users in the use of the mortar"
+  details: null
+- id: 235
+  weapon: "Mortar"
+  game: "DH"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 254
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows general knowledge of all rifles"
+  details: null
+- id: 255
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Marksman"
+  description: "Aims for targets chest"
+  details: null
+- id: 256
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Marksman"
+  description: "Knows when and how to effectively use melee"
+  details: null
+- id: 257
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Marksman"
+  description: "Keeps track of the number of rounds left"
+  details: null
+- id: 258
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows basic understanding of common weapon-based tricks and techniques"
+  details: null
+- id: 259
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Marksman"
+  description: "Properly adapts playstyle based on rifle"
+  details: null
+- id: 260
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 261
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Accurate at all ranges with iron sights"
+  details: null
+- id: 262
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Can effectively lead moving targets"
+  details: null
+- id: 263
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Shows solid reflexes and decision making"
+  details: null
+- id: 264
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Properly uses cover to maintain an effective defensive position"
+  details: null
+- id: 265
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Implements important gameplay techniques into everyday play"
+  details: null
+- id: 266
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows general knowledge of all sub-machine guns"
+  details: null
+- id: 267
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows effectiveness in building clearing"
+  details: null
+- id: 268
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Able to provide effective cover fire with the sub-machine gun"
+  details: null
+- id: 269
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Understands when to use each firing mode"
+  details: null
+- id: 270
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows basic understanding of effective sub-machine gun usage in offense and defence"
+  details: null
+- id: 271
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows proper use of smoke grenades to provide cover for teammates"
+  details: null
+- id: 272
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Able to eliminate multiple targets at a time"
+  details: null
+- id: 273
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Keeps track of the number of rounds left"
+  details: null
+- id: 274
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 275
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Able to defend an enclosed space alone"
+  details: null
+- id: 276
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Able to fire accurately and control recoil at medium ranges"
+  details: null
+- id: 277
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Frequently able to eliminate three or more targets at a time"
+  details: null
+- id: 278
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: null
+- id: 279
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Able to master short 3-round bursts to conserve ammunition and control recoil"
+  details: null
+- id: 280
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Shows effectiveness in building clearing with no casualties"
+  details: null
+- id: 281
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows general knowledge of all heavies"
+  details: null
+- id: 282
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Marksman"
+  description: "Understands recoil and the use of bursts to control it"
+  details: null
+- id: 283
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Marksman"
+  description: "Understands concepts of and shows basic skills of building clearing"
+  details: null
+- id: 284
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Marksman"
+  description: "Understands the idea of being a supporting element"
+  details: null
+- id: 285
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Marksman"
+  description: "Understands the effectiveness of pre-firing common positions"
+  details: null
+- id: 286
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Marksman"
+  description: "Properly adapts playstyle based on heavy"
+  details: null
+- id: 287
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Marksman"
+  description: "Can locate effective defensive positions"
+  details: null
+- id: 288
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 289
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Able to fire accurately and control recoil at medium to long range with iron sights"
+  details: null
+- id: 290
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Able to fire accurately and control recoil at medium to long range with deployed weapon"
+  details: null
+- id: 291
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Able to fire accurately and control recoil at close and medium range when firing from the hip"
+  details: null
+- id: 292
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Understands when to use single-shot and when to use burst fire"
+  details: null
+- id: 293
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: null
+- id: 294
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Able to effectively eliminate targets while on-the-move to destination"
+  details: null
+- id: 295
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Frequently able to clear a building single-handedly"
+  details: null
+- id: 296
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows general knowledge of all machine guns"
+  details: null
+- id: 297
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Can effectively provide suppressive MG fire"
+  details: null
+- id: 298
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Understands how and when to advance to support team"
+  details: null
+- id: 299
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "General understanding of timing involved in deploying/undeploying"
+  details: null
+- id: 300
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows an understanding of how to preserve MG barrels"
+  details: null
+- id: 301
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Frequently able to hold off an entire flank from an enclosed area of a map"
+  details: null
+- id: 302
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Deploys in areas providing as little visibility to the enemy as possible"
+  details: null
+- id: 303
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Frequently asks for support from another soldier to cover the flanks"
+  details: null
+- id: 304
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Understands what structures can be used for support"
+  details: null
+- id: 305
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 306
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Able to locate effective vantage points and positions automatically"
+  details: null
+- id: 307
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Frequently able to hold off an entire flank from an unenclosed area of a map"
+  details: null
+- id: 308
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Able to eliminate 3-5 targets before being spotted"
+  details: null
+- id: 309
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Always on the move; rarely in the same area for long"
+  details: null
+- id: 310
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: null
+- id: 311
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Able to quickly switch between numerous areas of deployment"
+  details: null
+- id: 312
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Sufficient reflexes between very thin areas"
+  details: null
+- id: 313
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Marksman"
+  description: "Can effectively use assigned secondary weapon"
+  details: null
+- id: 314
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows basic understanding of the advantages and limitations of each Engineer-specific weapon"
+  details: null
+- id: 315
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Marksman"
+  description: "Properly utilizes splash damage for building clearing and building defense"
+  details: null
+- id: 316
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Marksman"
+  description: "Understands potential friendly fire damage from anti-tank explosion or exhaust"
+  details: null
+- id: 317
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Marksman"
+  description: "Understands the idea of being a supporting element"
+  details: null
+- id: 318
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows basic understanding of common map positions and player positioning"
+  details: null
+- id: 319
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows basic understanding of Mortar firing modes and Flamethrower fire cone."
+  details: null
+- id: 320
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 321
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Accurate with Mortar at all ranges"
+  details: null
+- id: 322
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Shows indepth understanding of mortar projectile travel time"
+  details: null
+- id: 323
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Shows proper ammo management"
+  details: null
+- id: 324
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Effectively communicates with squad leaders to coordinate fire"
+  details: null
+- id: 325
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Shows knowledge of how to close in to flamethrower range"
+  details: null
+- id: 326
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Can effectively use mortar or flamethrower to effectively clear out fortified and window positions"
+  details: null
+- id: 327
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Indepth understanding of mortar splash-damage and flame behaviour/characteristics"
+  details: null
+- id: 328
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Shows vast knolwedge of common map positions and player positioning"
+  details: null
+- id: 330
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 331
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 332
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 333
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 334
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 335
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 336
+  weapon: "Rifle"
+  game: "RS"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 337
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 338
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 339
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 340
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 341
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 342
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 343
+  weapon: "Submachine Gun"
+  game: "RS"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 344
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 345
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 346
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 347
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 348
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 349
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 350
+  weapon: "Automatic Rifle"
+  game: "RS"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 351
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 352
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 353
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 354
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 355
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 356
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 357
+  weapon: "Machine Gun"
+  game: "RS"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 358
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 359
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 360
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 361
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 362
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 363
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 364
+  weapon: "Combat Engineer"
+  game: "RS"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 365
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows general knowledge of all rifles and attachments"
+  details: null
+- id: 366
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Aims for targets chest"
+  details: null
+- id: 367
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Keeps track of the number of rounds left"
+  details: null
+- id: 368
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control with weapon"
+  details: null
+- id: 369
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Capable of making distance calls to adjust for different ranges"
+  details: null
+- id: 370
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Comfortable with AIT appropriate sights"
+  details: null
+- id: 371
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Manages stamina properly"
+  details: null
+- id: 372
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Accurate at all ranges with all sights"
+  details: null
+- id: 373
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: null
+- id: 374
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Seeks effective firing positions"
+  details: null
+- id: 386
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Can effectively use scripted abilities such as repair which are typically assigned to Engineer class"
+  details: null
+- id: 387
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows general knowledge of all manner of anti-vehicle weapons and warhead types"
+  details: null
+- id: 388
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Understands the basic mechanics behind damaging armored vehicles"
+  details: null
+- id: 389
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows competency with AT weapon for building clearing purposes"
+  details: null
+- id: 390
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Understands potential friendly fire damage from proximity to vehicle explosion"
+  details: null
+- id: 391
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Understands the idea of being a supporting element"
+  details: null
+- id: 392
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Understands the timing involved in reloading deploying etc"
+  details: null
+- id: 393
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 394
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Accurate with antitank at all ranges"
+  details: null
+- id: 395
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Effectively targets vulnerable areas of tanks"
+  details: null
+- id: 396
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Effectively communicates with squad leaders to coordinate fire"
+  details: null
+- id: 397
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Shows strategic knowledge of how to close and flank armored vehicles"
+  details: null
+- id: 398
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Can effectively use the antitank to clear out fortified & window positions with dependable accuracy"
+  details: null
+- id: 399
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "In-depth understanding of antitank splash damage and anti-infantry tactics"
+  details: null
+- id: 400
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving vehicle"
+  details: null
+- id: 401
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Can defend oneself if downed"
+  details: null
+- id: 402
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows general knowledge of all aircraft"
+  details: null
+- id: 403
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Able to determine landing zone safety"
+  details: null
+- id: 404
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Uses common communication techniques"
+  details: null
+- id: 405
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Displays competence over takeoff and landing"
+  details: null
+- id: 406
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Scans FOV for enemy, prioritizing antiaircraft targets"
+  details: null
+- id: 407
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Can identify enemy ground and air vehicles by type"
+  details: null
+- id: 408
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Basic knowledge of all aircraft  mounted weapons"
+  details: null
+- id: 409
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Able to provide CAS and CAP at a competent level"
+  details: null
+- id: 410
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 411
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Can instantly convert to effective ground unit if downed"
+  details: null
+- id: 412
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Shows advanced knowledge of all aircraft"
+  details: null
+- id: 413
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Advanced knowledge of all aircraft mounted weapons"
+  details: null
+- id: 414
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Effective gunnery with standoff and close support weapons"
+  details: null
+- id: 415
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Able to work with ground units seamlessly"
+  details: null
+- id: 416
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Can effectively command crew of aircraft"
+  details: null
+- id: 417
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Logically averts obstacles within scope of orders"
+  details: null
+- id: 418
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Can effectively maneuver against enemy aircraft"
+  details: null
+- id: 419
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Knows what weapon systems are used on what target type"
+  details: null
+- id: 420
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Chooses most effective angles of attack"
+  details: null
+- id: 421
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows general knowledge of all tanks and armored vehicles"
+  details: null
+- id: 422
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Uses common communication techniques"
+  details: null
+- id: 423
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Displays mastery over the oclock system and compass"
+  details: null
+- id: 424
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Scans FOV for enemy prioritizing antitank targets"
+  details: null
+- id: 425
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Can identify enemy vehicle type"
+  details: null
+- id: 426
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Understands flex and arc"
+  details: null
+- id: 427
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Basic knowledge of all vehicle mounted weapons "
+  details: null
+- id: 428
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Recognizes situations where firing would give away their position"
+  details: null
+- id: 429
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Moves tank only when directed"
+  details: null
+- id: 430
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 431
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Understands the different shell types"
+  details: null
+- id: 432
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Effective gunnery at long ranges"
+  details: null
+- id: 433
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Able to work with other tanks "
+  details: null
+- id: 434
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Effective as a ornamenting when necessary"
+  details: null
+- id: 435
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Logically averts obstacles within scope of orders"
+  details: null
+- id: 436
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Can effectively maneuver against an enemy tank"
+  details: null
+- id: 437
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Knows what ammunition is used on what target type"
+  details: null
+- id: 438
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Knowledge of obstacles and what a tank can traverse"
+  details: null
+- id: 439
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Knows how to angle or defilade the tank to provide the most protection"
+  details: null
+- id: 440
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 441
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 442
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 443
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 444
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 445
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 446
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 454
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 455
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 456
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 457
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 458
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 459
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 460
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 461
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows general knowledge of all automatic rifles"
+  details: null
+- id: 462
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Understands recoil and the use of burst to control it"
+  details: null
+- id: 463
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Understands the concepts of and shows basic skills of suppressive fire"
+  details: null
+- id: 464
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Can locate effective overwatch firing positions"
+  details: null
+- id: 465
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Can locate effective defensive firing positions"
+  details: null
+- id: 466
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control with weapon and optics"
+  details: null
+- id: 467
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Able to fire accurately and control recoil at medium to long range with iron sights and optics"
+  details: null
+- id: 468
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Understands when to use single-shot and when to use burst fire"
+  details: null
+- id: 469
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: null
+- id: 470
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Can immobilize soft skinned or light armored vehicles"
+  details: null
+- id: 471
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 472
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 473
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 474
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 475
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 476
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 477
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 478
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows general knowledge of all sniper rifles"
+  details: null
+- id: 479
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Marksman"
+  description: "Can effectively use base ironsights on a sniper rifle"
+  details: null
+- id: 480
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Marksman"
+  description: "Able to locate and report high priority target locations accurately"
+  details: null
+- id: 481
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Marksman"
+  description: "Understands and applies the fundamental elements of positioning"
+  details: null
+- id: 482
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Marksman"
+  description: "Can effectively track and eliminate a target in territory with dense cover"
+  details: null
+- id: 483
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Marksman"
+  description: "Understands the importance of fire discipline"
+  details: null
+- id: 484
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 485
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Can effectively manage bullet drop"
+  details: null
+- id: 486
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target at long range"
+  details: null
+- id: 487
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Ability to maneuver the battlefield undetected"
+  details: null
+- id: 488
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Ability to judge if the current position is compromised and disengage if need be"
+  details: null
+- id: 489
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Can stalk and eliminate a specific target in enemy territory"
+  details: null
+- id: 490
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Able to quickly and efficiently eliminate multiple targets in quick succession"
+  details: null
+- id: 491
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 492
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 493
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 494
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 495
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 496
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Expert"
+  description: "Can instruct AIT users in the use of the sniper rifle"
+  details: null
+- id: 497
+  weapon: "Sniper"
+  game: "RS"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 498
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows general knowledge of all sniper rifles"
+  details: null
+- id: 499
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Can effectively use base ironsights on a sniper rifle"
+  details: null
+- id: 500
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Able to locate and report high priority target locations accurately"
+  details: null
+- id: 501
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Understands and applies the fundamental elements of positioning"
+  details: null
+- id: 502
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Can effectively track and eliminate a target in territory with dense cover"
+  details: null
+- id: 503
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Understands the importance of fire discipline"
+  details: null
+- id: 504
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 505
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Can effectively manage bullet drop"
+  details: null
+- id: 506
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target at long range"
+  details: null
+- id: 507
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Ability to maneuver the battlefield undetected"
+  details: null
+- id: 508
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Ability to judge if the current position is compromised and disengage if need be"
+  details: null
+- id: 509
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Can stalk and eliminate a specific target in enemy territory"
+  details: null
+- id: 510
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Able to quickly and efficiently eliminate multiple targets in quick succession"
+  details: null
+- id: 511
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 513
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 514
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 515
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 516
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Can instruct AIT users in the use of the sniper rifle"
+  details: null
+- id: 517
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 518
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Able to identify the best tanking positions"
+  details: null
+- id: 519
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Effective gunnery on the move"
+  details: null
+- id: 520
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Effective use of blind spots and dead ground"
+  details: null
+- id: 521
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Knows the soft spots of enemy vehicles"
+  details: null
+- id: 522
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Understands land navigation and infantry interface"
+  details: null
+- id: 523
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Prioritizes between enemy tanks and enemy infantry"
+  details: null
+- id: 524
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Accurately estimates range/timing to achieve first shot hit"
+  details: null
+- id: 525
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness, crisis management, and aversion to friendly fire"
+  details: null
+- id: 526
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Can instruct AIT users in the use of the tank"
+  details: null
+- id: 527
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 528
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Accurate at the longest ranges"
+  details: null
+- id: 529
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Can effectively manage wind speed"
+  details: null
+- id: 530
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Effective with sidearms"
+  details: null
+- id: 531
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Can effectively range a target without using range finding capable equipment"
+  details: null
+- id: 532
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Demonstrates effective defensive maneuvering and use of countermeasures to defeat AA threats"
+  details: null
+- id: 533
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Capable of landing and taking off in an enclosed or restricted LZ"
+  details: null
+- id: 534
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "When tasked to, acts as an effective recon asset for ground forces including accurately marking targets"
+  details: null
+- id: 535
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Conducts correct type of attack for target and threat level"
+  details: null
+- id: 536
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Shows near perfect control and accuracy with dumbfire weapons"
+  details: null
+- id: 537
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Can instruct AIT users in the use of aircraft"
+  details: null
+- id: 538
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Shows near perfect situational awareness and crisis management"
+  details: null
+- id: 539
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Has distinguished themselves on Battalion level"
+  details: null
+- id: 540
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Able to manage loadout weight while maintaining AIT effectiveness"
+  details: null
+- id: 541
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Able to manage loadout weight while maintaining AIT effectiveness"
+  details: null
+- id: 542
+  weapon: "Pilot"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Able to manage loadout weight while maintaining AIT effectiveness"
+  details: null
+- id: 543
+  weapon: "Armor"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Able to manage loadout weight while maintaining AIT effectiveness"
+  details: null
+- id: 544
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Able to manage loadout weight while maintaining AIT effectiveness"
+  details: null
+- id: 545
+  weapon: "Sniper"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Able to manage loadout weight while maintaining AIT effectiveness"
+  details: null
+- id: 546
+  weapon: "Automatic Rifle"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Able to effectively set-up and manoeuvre tripod mounted MG"
+  details: null
+- id: 547
+  weapon: "Combat Engineer"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Able to effectively set-up and manoeuvre tripod mounted Launchers"
+  details: null
+- id: 548
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Demonstrates skill with 40mm grenade launcher and ammo types"
+  details: null
+- id: 549
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Can effectively create a smokescreen for offensive purposes"
+  details: null
+- id: 550
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Understands the idea of being a supporting element"
+  details: null
+- id: 551
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Understands the timing involved in reloading, deploying, etc"
+  details: null
+- id: 552
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Effectively communicates with squad leaders to coordinate fire"
+  details: null
+- id: 553
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Able to manage loadout weight while maintaining AIT effectiveness"
+  details: null
+- id: 554
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 555
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Able to effectively set-up and manoeuvre tripod mounted GMG"
+  details: null
+- id: 556
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Accurate at medium range with all sights"
+  details: null
+- id: 557
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Can effectively create a smokescreen for defensive purposes"
+  details: null
+- id: 558
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Seeks effective firing positions"
+  details: null
+- id: 559
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "General knowledge of all ammunition types"
+  details: null
+- id: 560
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: null
+- id: 561
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Understands using the splash effect on entrenched enemy positions"
+  details: null
+- id: 562
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Understands minimum ranges and how to avoid friendly fire"
+  details: null
+- id: 563
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 564
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 565
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 566
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 567
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 568
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 569
+  weapon: "Grenadier"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 570
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows general knowledge of all sub-machine guns"
+  details: null
+- id: 571
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows effectiveness in building clearing"
+  details: null
+- id: 572
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Able to provide effective cover fire with the submachine gun"
+  details: null
+- id: 573
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Able to eliminate multiple targets at a time"
+  details: null
+- id: 574
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Keeps track of the number of rounds left"
+  details: null
+- id: 575
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Understands when to use each firing mode"
+  details: null
+- id: 576
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 577
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Marksman"
+  description: "Uses hip fire when clearing buildings and in CQB"
+  details: null
+- id: 578
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Able to fire accurately and control recoil at medium ranges while firing from the hip with sub-machine guns"
+  details: null
+- id: 579
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Able to fire accurately and control recoil with iron sights at medium range with sub-machine guns"
+  details: null
+- id: 580
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Frequently able to eliminate three or more targets at a time"
+  details: null
+- id: 581
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: null
+- id: 582
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Able to master short 3-round bursts to conserve ammunition and control recoil"
+  details: null
+- id: 583
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Shows effectiveness in building clearing with no casualties"
+  details: null
+- id: 584
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Able to defend an enclosed space alone"
+  details: null
+- id: 585
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Understands how and when to fire \"around\" body armor"
+  details: null
+- id: 586
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 587
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Does not make game play errors that lead to death"
+  details: null
+- id: 588
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 589
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 590
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 591
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Can instruct AIT users in the use of the support class"
+  details: null
+- id: 592
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 593
+  weapon: "Submachine Gun"
+  game: "Arma 3"
+  badge: "Expert"
+  description: "Able to be effective over 300 meters"
+  details: null
+- id: 594
+  weapon: "Armor"
+  game: "RS"
+  badge: "Marksman"
+  description: "Moves tank when directed by leadership"
+  details: null
+- id: 595
+  weapon: "Armor"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows general knowledge of tank maneuverability"
+  details: null
+- id: 596
+  weapon: "Armor"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows understanding of the o'clock system"
+  details: null
+- id: 597
+  weapon: "Armor"
+  game: "RS"
+  badge: "Marksman"
+  description: "Scans FOV for enemy, prioritizing anti-tank targets"
+  details: null
+- id: 598
+  weapon: "Armor"
+  game: "RS"
+  badge: "Marksman"
+  description: "Understands flex and arc"
+  details: null
+- id: 599
+  weapon: "Armor"
+  game: "RS"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 600
+  weapon: "Armor"
+  game: "RS"
+  badge: "Marksman"
+  description: "Coordinates with infantry to cover blind spots/flanks"
+  details: null
+- id: 601
+  weapon: "Armor"
+  game: "RS"
+  badge: "Marksman"
+  description: "Understands when to provide supporting fire"
+  details: null
+- id: 602
+  weapon: "Armor"
+  game: "RS"
+  badge: "Marksman"
+  description: "Aware of all the weak spots for each tank model"
+  details: null
+- id: 603
+  weapon: "Armor"
+  game: "RS"
+  badge: "Marksman"
+  description: "Knowledge of obstacles and what a tank can traverse"
+  details: null
+- id: 604
+  weapon: "Armor"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Uses cover/dead space to protect the tank"
+  details: null
+- id: 605
+  weapon: "Armor"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Consistently gauge distances accurately on first attempt"
+  details: null
+- id: 606
+  weapon: "Armor"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Seamlessly coordinates with supporting platoon sized infantry teams"
+  details: null
+- id: 607
+  weapon: "Armor"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Can effectively maneuver against an enemy tank"
+  details: null
+- id: 608
+  weapon: "Armor"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Logically averts obstacles within scope of orders"
+  details: null
+- id: 609
+  weapon: "Armor"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Knows how to angle the tank to provide the most protection"
+  details: null
+- id: 610
+  weapon: "Armor"
+  game: "RS"
+  badge: "Sharpshooter"
+  description: "Knows what ammunition is used on what target type"
+  details: null
+- id: 611
+  weapon: "Armor"
+  game: "RS"
+  badge: "Expert"
+  description: "Understands land navigation and infantry interface"
+  details: null
+- id: 612
+  weapon: "Armor"
+  game: "RS"
+  badge: "Expert"
+  description: "Prioritizes between enemy tanks and enemy infantry"
+  details: null
+- id: 613
+  weapon: "Armor"
+  game: "RS"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness, crisis management, and aversion to friendly fire"
+  details: null
+- id: 614
+  weapon: "Armor"
+  game: "RS"
+  badge: "Expert"
+  description: "Able to reliably operate both primary and secondary weapons while tank is in constant motion"
+  details: null
+- id: 615
+  weapon: "Armor"
+  game: "RS"
+  badge: "Expert"
+  description: "Can instruct AIT users in the use of the tank"
+  details: null
+- id: 616
+  weapon: "Armor"
+  game: "RS"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 617
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Shows knowledge of and proficiency with attachments and optics"
+  details: null
+- id: 618
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Understands how to defeat body armour"
+  details: null
+- id: 619
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Always selects proper fire mode based on engagement type"
+  details: null
+- id: 620
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Understands bullet penetration for different calibres"
+  details: null
+- id: 621
+  weapon: "Rifle"
+  game: "Arma 3"
+  badge: "Sharpshooter"
+  description: "Maintains fire discipline at all times"
+  details: null
+- id: 622
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows general knowledge of all rifles"
+  details: "How many shots they hold, how much damage they do, where to aim with them"
+- id: 638
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 647
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control with weapon"
+  details: ""
+- id: 660
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Knows when and how to effectively use melee"
+  details: null
+- id: 661
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Knows when to use semi and full automatic fire."
+  details: null
+- id: 662
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Keeps track of the number of rounds left"
+  details: null
+- id: 663
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows basic understanding of common weapon-based tricks and techniques"
+  details: null
+- id: 664
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Properly adapts playstyle based on rifle"
+  details: null
+- id: 665
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 666
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Can effectively conserve ammo by burst fire when needed."
+  details: null
+- id: 667
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Accurate at all ranges with iron sights"
+  details: null
+- id: 668
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Can effectively lead moving targets"
+  details: null
+- id: 669
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Shows solid reflexes and decision making"
+  details: null
+- id: 670
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Properly uses cover to maintain an effective defensive position"
+  details: null
+- id: 671
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Implements important gameplay techniques into everyday play"
+  details: null
+- id: 672
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Always selects proper fire mode based on engagement type"
+  details: null
+- id: 673
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Understands bullet penetration"
+  details: null
+- id: 674
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Maintains fire discipline at all times"
+  details: null
+- id: 675
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 676
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 677
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 678
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 679
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 680
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 681
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows general knowledge of all CQC Weapons"
+  details: null
+- id: 682
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows effectiveness in building clearing"
+  details: null
+- id: 683
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Able to provide effective cover fire with the sub-machine gun"
+  details: null
+- id: 684
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows accurate knowledge of Shotgun ammo types and their effective usage"
+  details: null
+- id: 685
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows basic understanding of weapon usage in offense and defense"
+  details: null
+- id: 686
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows proper use of smoke grenades to provide cover for teammates"
+  details: null
+- id: 687
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Able to eliminate multiple targets at a time"
+  details: null
+- id: 688
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Keeps track of the number of rounds left"
+  details: null
+- id: 689
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 690
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Uses hip fire when clearing buildings and in CQB"
+  details: null
+- id: 691
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Able to defend an enclosed space alone"
+  details: null
+- id: 692
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Able to fire accurately and control recoil at medium ranges"
+  details: null
+- id: 693
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Frequently able to eliminate three or more targets at a time"
+  details: null
+- id: 694
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: null
+- id: 695
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Able to master ammo conservation"
+  details: null
+- id: 696
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Shows effectiveness in building clearing with no casualties"
+  details: null
+- id: 697
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Able to master killing enemies without exposing self in building clearing"
+  details: null
+- id: 698
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 699
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 700
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 701
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 702
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 703
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 704
+  weapon: "Submachine Gun"
+  game: "RS2"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 705
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows general knowledge of all machine guns"
+  details: null
+- id: 706
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Can effectively provide suppressive MG fire"
+  details: null
+- id: 707
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Understands how and when to advance to support team"
+  details: null
+- id: 708
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "General understanding of timing involved in deploying/undeploying"
+  details: null
+- id: 709
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows an understanding of how to preserve MG barrels"
+  details: null
+- id: 710
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Frequently able to hold off an entire flank from an enclosed area of a map"
+  details: null
+- id: 711
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Deploys in areas providing as little visibility to the enemy as possible"
+  details: null
+- id: 712
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Frequently asks for support from another soldier to cover the flanks"
+  details: null
+- id: 713
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 714
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Able to locate effective vantage points and positions automatically"
+  details: null
+- id: 715
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Able to utilize a spotter to find targets"
+  details: null
+- id: 716
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Able to eliminate 3-5 targets before being spotted"
+  details: null
+- id: 717
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Always on the move; rarely in the same area for long"
+  details: null
+- id: 718
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: null
+- id: 719
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Able to quickly switch between numerous areas of deployment"
+  details: null
+- id: 720
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Sufficient reflexes between very thin areas"
+  details: null
+- id: 721
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Mastered mounted and unmounted aimed recoil."
+  details: null
+- id: 722
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 723
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 724
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 725
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 726
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 727
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 728
+  weapon: "Machine Gun"
+  game: "RS2"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 729
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Can effectively use assigned secondary weapon / secondary functions"
+  details: null
+- id: 730
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows basic understanding of the advantages and limitations of each Engineer-specific weapon"
+  details: null
+- id: 731
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Properly utilizes splash damage for building clearing and building defense"
+  details: null
+- id: 732
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Understands potential friendly fire damage from AIT weapons"
+  details: null
+- id: 733
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Understands the idea of being a supporting element"
+  details: null
+- id: 734
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows basic understanding of common map positions and player positioning"
+  details: null
+- id: 735
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 736
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Accurate with RPG and M79 Grenade Launcher at all ranges"
+  details: null
+- id: 737
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Shows in-depth understanding of Flamethrower fire cone and physic effects"
+  details: null
+- id: 738
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Shows proper ammo management"
+  details: null
+- id: 739
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Effectively communicates with squad leaders to coordinate fire"
+  details: null
+- id: 740
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Shows knowledge of how to close in to flamethrower range"
+  details: null
+- id: 741
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Can effectively use RPG / M79 / Flamethrower to effectively clear out fortified and window positions"
+  details: null
+- id: 742
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "In-depth understanding of explosive splash-damage and flame behavior/characteristics"
+  details: null
+- id: 743
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Shows vast knowledge of common map positions and player positioning"
+  details: null
+- id: 744
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 745
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 746
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 747
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 748
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 749
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 750
+  weapon: "Combat Engineer"
+  game: "RS2"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 751
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows general knowledge of all sniper rifles"
+  details: null
+- id: 752
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Can effectively use base iron-sights / alternative sights on a sniper rifle"
+  details: null
+- id: 753
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Able to locate and report high priority target locations accurately"
+  details: null
+- id: 754
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Understands and applies the fundamental elements of positioning"
+  details: null
+- id: 755
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Can effectively track and eliminate a target in territory with dense cover"
+  details: null
+- id: 756
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Understands the importance of fire discipline"
+  details: null
+- id: 757
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 758
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Understands the importance of maintaining distance from enemies"
+  details: null
+- id: 759
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Can effectively manage bullet drop"
+  details: null
+- id: 760
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target at long range"
+  details: null
+- id: 761
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Ability to maneuver the battlefield undetected"
+  details: null
+- id: 762
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Ability to give Squad Leader intelligence on enemy movement and positions"
+  details: null
+- id: 763
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Ability to judge if the current position is compromised and disengage if need be"
+  details: null
+- id: 764
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Can stalk and eliminate a specific target in enemy territory"
+  details: null
+- id: 765
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Able to quickly and efficiently eliminate multiple targets in quick succession"
+  details: null
+- id: 766
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 767
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 768
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 769
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 770
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 771
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Expert"
+  description: "Can instruct AIT users in the use of the sniper rifle"
+  details: null
+- id: 772
+  weapon: "Sniper"
+  game: "RS2"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 773
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Shows general knowledge of all rifles"
+  details: null
+- id: 774
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Aims for target`s chest"
+  details: null
+- id: 775
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Can effectively control full-auto recoil in close quarters situations"
+  details: null
+- id: 776
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Properly uses cover to maintain an effective fighting position"
+  details: null
+- id: 777
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Keeps track of the number of rounds left"
+  details: null
+- id: 778
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Can differentiate gameplay style based on rifle"
+  details: null
+- id: 779
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Shows proficency at all ranges with all sights"
+  details: null
+- id: 780
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Can effectively lead moving targets"
+  details: null
+- id: 781
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Shows solid reflexes and decision making skills"
+  details: null
+- id: 782
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Understands bullet penetration for different calibres"
+  details: null
+- id: 783
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Maintains fire discipline at all times"
+  details: null
+- id: 784
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Has distinguished himself at a Company level"
+  details: null
+- id: 785
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 786
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 787
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 788
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 789
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 790
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 791
+  weapon: "Rifle"
+  game: "Squad"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 792
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Shows general knowledge of all anti-tank weapons"
+  details: null
+- id: 793
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Understands the basic mechanics behind damaging tanks"
+  details: null
+- id: 794
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Shows basic knowledge of using the anti-tank for building clearing purposes"
+  details: null
+- id: 795
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Understands potential friendly fire damage from anti-tank explosion or exhaust"
+  details: null
+- id: 796
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Understands the idea of being a supporting element"
+  details: null
+- id: 797
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Understands the timing involved in reloading, deploying, etc."
+  details: null
+- id: 798
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 799
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Accurate with anti-Tank at all ranges"
+  details: null
+- id: 801
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Maintains teamwork with provided supplier for faster rate of fire"
+  details: null
+- id: 802
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Effectively communicates with squad leaders to coordinate fire"
+  details: null
+- id: 803
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Shows knowledge of how to close in and flank around armored vehicles"
+  details: null
+- id: 804
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Can effectively use the anti-tank to clear out fortified & window positions"
+  details: null
+- id: 805
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Indepth understanding of anti-tank splash-damage and anti-infantry tactics"
+  details: null
+- id: 806
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving vehicle"
+  details: null
+- id: 807
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Effectively uses each projectile range on the different anti-tank weapons"
+  details: null
+- id: 808
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Has a vast knowledge of tank statistics"
+  details: null
+- id: 809
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 810
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 811
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 812
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 813
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 814
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 815
+  weapon: "Combat Engineer"
+  game: "Squad"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 816
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Demonstrates skill with the M203/GP-25"
+  details: null
+- id: 817
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Can effectively create a smokescreen for offensive purposes"
+  details: null
+- id: 818
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Understands the idea of being a supporting element"
+  details: null
+- id: 819
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Understands the timing involved in reloading, deploying, etc"
+  details: null
+- id: 820
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Effectively communicates with squad leaders to coordinate fire"
+  details: null
+- id: 821
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 822
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Accurate at medium range with all sights"
+  details: null
+- id: 823
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Can effectively create a smokescreen for defensive purposes"
+  details: null
+- id: 824
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Seeks effective firing positions"
+  details: null
+- id: 825
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: null
+- id: 826
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Understands using the splash effect on entrenched enemy positions"
+  details: null
+- id: 827
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Understands minimum ranges and how to avoid friendly fire"
+  details: null
+- id: 828
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 829
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 830
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 831
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 832
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 833
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 834
+  weapon: "Grenadier"
+  game: "Squad"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 835
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Shows general knowledge of all automatic rifles"
+  details: null
+- id: 836
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Understands recoil and the use of burst to control it"
+  details: null
+- id: 837
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Understands the concepts of and shows basic skills of suppressive fire"
+  details: null
+- id: 838
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Understands concepts of and shows basic skills of building clearing"
+  details: null
+- id: 839
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Understands the idea of being a supporting element"
+  details: null
+- id: 840
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Understands the effectiveness of pre-firing"
+  details: null
+- id: 841
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control with weapon"
+  details: null
+- id: 842
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Able to fire accurately and control recoil at medium to long range with iron sights and optics"
+  details: null
+- id: 843
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Understands when to use single-shot and when to use burst fire"
+  details: null
+- id: 844
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: null
+- id: 845
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Seeks effective firing positions"
+  details: null
+- id: 846
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Shows solid ammo management skills"
+  details: null
+- id: 847
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Frequently able to clear a building single-handedly"
+  details: null
+- id: 848
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 849
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 850
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 851
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 852
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 853
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 854
+  weapon: "Automatic Rifle"
+  game: "Squad"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 855
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Shows general knowledge of all sniper rifles"
+  details: null
+- id: 856
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Can effectively use secondary weapon assigned to Sniper class"
+  details: null
+- id: 857
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Able to locate and report high priority target locations accurately"
+  details: null
+- id: 858
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Understands the importance of maintaining distance from enemies"
+  details: null
+- id: 859
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Can effectively stalk and eliminate a target in territory with dense cover"
+  details: null
+- id: 860
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Understands the importance of fire discipline"
+  details: null
+- id: 861
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Shows acquired comfort and control"
+  details: null
+- id: 862
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Accurate at short and medium ranges when firing from the hip"
+  details: null
+- id: 863
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Accurate at the longest range with iron sights"
+  details: null
+- id: 864
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Can effectively lead a moving target"
+  details: null
+- id: 865
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Ability to move from cover to cover without detection"
+  details: null
+- id: 866
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Able to evade and escape enemy contact if detected"
+  details: null
+- id: 867
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Able to articulate and relay enemy classes and positions accurately"
+  details: null
+- id: 868
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Can stalk and eliminate a target in territory with sparse cover"
+  details: null
+- id: 869
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Expert"
+  description: "Frequently outperforms his peers in pub play, drills, and scrimmages"
+  details: null
+- id: 870
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Expert"
+  description: "Does not make gameplay errors that lead to death"
+  details: null
+- id: 871
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Expert"
+  description: "Able to successfully carry out orders independently"
+  details: null
+- id: 872
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Expert"
+  description: "Effectively locates suitable cover and shooting locations while on the move to objectives"
+  details: null
+- id: 873
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Expert"
+  description: "Shows near-perfect situational awareness and crisis management"
+  details: null
+- id: 874
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Expert"
+  description: "Can instruct assigned users in the use of the AIT"
+  details: null
+- id: 875
+  weapon: "Sniper"
+  game: "Squad"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 876
+  weapon: "Rifle"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Aims for target's chest"
+  details: null
+- id: 877
+  weapon: "SLT"
+  game: ""
+  badge: "N/A"
+  description: "Reviewed and Discussed Lesson 1"
+  details: null
+- id: 878
+  weapon: "SLT"
+  game: ""
+  badge: "N/A"
+  description: "Reviewed and Discussed Lesson 2"
+  details: null
+- id: 879
+  weapon: "SLT"
+  game: ""
+  badge: "N/A"
+  description: "Reviewed and Discussed Lesson 3"
+  details: null
+- id: 880
+  weapon: "SLT"
+  game: ""
+  badge: "N/A"
+  description: "Reviewed and Discussed Lesson 4"
+  details: null
+- id: 881
+  weapon: "SLT"
+  game: ""
+  badge: "N/A"
+  description: "Reviewed and Discussed Lesson 5"
+  details: null
+- id: 882
+  weapon: "SLT"
+  game: ""
+  badge: "N/A"
+  description: "Completed Task 1"
+  details: null
+- id: 883
+  weapon: "SLT"
+  game: ""
+  badge: "N/A"
+  description: "Completed Task 2"
+  details: null
+- id: 884
+  weapon: "SLT"
+  game: ""
+  badge: "N/A"
+  description: "Completed Task 3"
+  details: null
+- id: 885
+  weapon: "SLT"
+  game: ""
+  badge: "N/A"
+  description: "Completed Task 4"
+  details: null
+- id: 886
+  weapon: "SLT"
+  game: ""
+  badge: "N/A"
+  description: "Has shown the ability to rationally interpret situations with impartiality."
+  details: null
+- id: 887
+  weapon: "SLT"
+  game: ""
+  badge: "N/A"
+  description: "Has maintained attendance, skills and decorum appropriate of a SLT candidate."
+  details: null
+- id: 888
+  weapon: "SLT"
+  game: ""
+  badge: "N/A"
+  description: "Has developed his/her own personal leadership style."
+  details: null
+- id: 889
+  weapon: "SLT"
+  game: ""
+  badge: "N/A"
+  description: "Understands how to be an effective link in the Chain of Command."
+  details: null
+- id: 890
+  weapon: "SLT"
+  game: ""
+  badge: "N/A"
+  description: "Understands the importance of Squad management both on and off the field."
+  details: null
+- id: 891
+  weapon: "SLT"
+  game: ""
+  badge: "N/A"
+  description: "Maintains positive relationships both in the 29th and its communities."
+  details: null
+- id: 892
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Shows general knowledge of all tanks and armored vehicles"
+  details: null
+- id: 893
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Constantly scans for potential targets, prioritizing enemy anti-tank targets"
+  details: null
+- id: 894
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Takes proper precautions when driving to avoid getting stuck or tipping over"
+  details: null
+- id: 895
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Shows general map knowledge regarding suitable driving routes"
+  details: null
+- id: 896
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Selects suitable ammunition types depending on target"
+  details: null
+- id: 897
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Understands how to use the range finder to land accurate shots at medium range"
+  details: null
+- id: 898
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Effectively uses commander's override to help gunner acquire targets"
+  details: null
+- id: 899
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Keeps tank properly positioned for maximum survivability while simultaneously supporting the team"
+  details: null
+- id: 900
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Understands basic concepts of being a supporting element for the infantry"
+  details: null
+- id: 901
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Maintains communication and coordination with team leadership"
+  details: null
+- id: 902
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Marksman"
+  description: "Does not endanger friendly forces with own weaponry"
+  details: null
+- id: 903
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Rarely makes driving mistakes which lead to getting the vehicle stuck or tipped over"
+  details: null
+- id: 904
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Automatically makes excellent decisions regarding tank positioning"
+  details: null
+- id: 905
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Effective gunnery at long ranges"
+  details: null
+- id: 906
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Can accurately hit specific vulnerabilities on enemy vehicles"
+  details: null
+- id: 907
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Can effectively manage multiple lines of communication between crew and team"
+  details: null
+- id: 908
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Can interpret team leader's orders and provide the most effective armor support possible"
+  details: null
+- id: 909
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Sharpshooter"
+  description: "Uses hard cover and hull down position to improve survivability"
+  details: null
+- id: 910
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Expert"
+  description: "Works closely with the gunner to move in and out of cover while engaging enemy"
+  details: null
+- id: 911
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Expert"
+  description: "Maintains situational awareness even in the confines of the driver position"
+  details: null
+- id: 912
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Expert"
+  description: "Effective gunnery on the move and at maximum ranges"
+  details: null
+- id: 913
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Expert"
+  description: "Efficiently uses ammunition of all types to avoid running dry and quickly neutralize the enemy"
+  details: null
+- id: 914
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Expert"
+  description: "Accurately predicts enemy decisions and movement"
+  details: null
+- id: 915
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Expert"
+  description: "Can instruct AIT users in armored warfare"
+  details: null
+- id: 916
+  weapon: "Armor"
+  game: "Squad"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level"
+  details: null
+- id: 917
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Can identify good candidates for an LZ."
+  details: null
+- id: 918
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Uses the loach\u2019s spotting ability to recon effectively."
+  details: null
+- id: 919
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Able to evasively fly when under fire."
+  details: null
+- id: 920
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Shows general knowledge of all aircraft."
+  details: null
+- id: 921
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Constantly scans for potential targets, prioritizing enemy anti-air targets."
+  details: null
+- id: 922
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Understands basic concepts of being a supporting element for the infantry."
+  details: null
+- id: 923
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Maintains communication and coordination with team leadership."
+  details: null
+- id: 924
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Does not endanger friendly forces with own weaponry."
+  details: null
+- id: 925
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Can effectively utilize the gunner position on attack helicopters."
+  details: null
+- id: 926
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Is able to efficiently land and deploy troops as a transport pilot."
+  details: null
+- id: 927
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Is able to effectively employ combat helicopter weapon systems."
+  details: null
+- id: 928
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Marksman"
+  description: "Can defend oneself if downed."
+  details: null
+- id: 929
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Knows placement of airbases and when to use them."
+  details: null
+- id: 930
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Is able to remain safe from SAM sites (<75 meters of altitude)."
+  details: null
+- id: 931
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Can identify likely areas for enemy AA placement and enemy troop movement."
+  details: null
+- id: 932
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Rarely makes piloting mistakes that lead to the loss of the aircraft."
+  details: null
+- id: 933
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Effective gunnery at extremely long ranges."
+  details: null
+- id: 934
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Can effectively manage multiple lines of communication between crew and team."
+  details: null
+- id: 935
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Can conserve airspeed and energy to return to base with damaged components."
+  details: null
+- id: 936
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Sharpshooter"
+  description: "Shows advanced knowledge of all aircraft."
+  details: null
+- id: 937
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Expert"
+  description: "Has mastered all gun systems available."
+  details: null
+- id: 938
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Expert"
+  description: "Can lead a moving spotting indicator to kill an enemy that is completely obscured."
+  details: null
+- id: 939
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Expert"
+  description: "Can conserve airspeed and energy to return to base with totally destroyed components."
+  details: null
+- id: 940
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Expert"
+  description: "Works closely with the gunner to maximize weapons platform effectiveness."
+  details: null
+- id: 941
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Expert"
+  description: "Maintains situational awareness at all times."
+  details: null
+- id: 942
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Expert"
+  description: "Can instruct AIT users in air asset warfare."
+  details: null
+- id: 943
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Expert"
+  description: "Can perform unorthodox troop insertion."
+  details: null
+- id: 944
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Expert"
+  description: "Shows near perfect situational awareness and crisis management."
+  details: null
+- id: 945
+  weapon: "Pilot"
+  game: "RS2"
+  badge: "Expert"
+  description: "Has distinguished himself at a Battalion level."
+  details: null

--- a/db/seeds/data/awards.yml
+++ b/db/seeds/data/awards.yml
@@ -1,0 +1,2124 @@
+- id: 1
+  code: "dsc"
+  title: "Distinguished Service Cross"
+  description: "Exceptional in every regard. The highest honor attainable in the 29th Infantry Division."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/dsc.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/dsc_.gif"
+  bar: "http://personnel.29th.org/images/awards/dsc.gif"
+  active: true
+  order: 500
+  display_filename: "dsc.gif"
+  mini_filename: "dsc.gif"
+- id: 2
+  code: "sstar"
+  title: "Silver Star"
+  description: "This soldier has demonstrated perfect performance whilst engaging with the enemy, that not only single-handedly secured victory for his team, but demonstrated the core principles of being an effective soldier in the 29th Infantry Division. This medal is only awarded when the soldier's game-play was at a level of the highest calibre."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/sstar.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/sstar_.gif"
+  bar: "http://personnel.29th.org/images/awards/sstar.gif"
+  active: true
+  order: 390
+  display_filename: "sstar.gif"
+  mini_filename: "sstar.gif"
+- id: 3
+  code: "lom"
+  title: "Legion of Merit"
+  description: "Awarded for leading and winning an Official Scrimmage."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/lom.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/lom_.gif"
+  bar: "http://personnel.29th.org/images/awards/lom.gif"
+  active: true
+  order: 300
+  display_filename: "lom.gif"
+  mini_filename: "lom.gif"
+- id: 4
+  code: "sm"
+  title: "Soldier's Medal"
+  description: "This soldier's extensive preparation during practice or drills prior to a scrimmage or drill prevented casualties by providing vital intelligence or training for his team."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/sm.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/sm_.gif"
+  bar: "http://personnel.29th.org/images/awards/sm.gif"
+  active: true
+  order: 350
+  display_filename: "sm.gif"
+  mini_filename: "sm.gif"
+- id: 5
+  code: "bstar"
+  title: "Bronze Star"
+  description: "This soldier has demonstrated exemplary performance while engaging the enemy in a realism scrimmage. While not single handedly securing victory, his actions must have been of significance."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/bstar.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/bstar_.gif"
+  bar: "http://personnel.29th.org/images/awards/bstar.gif"
+  active: true
+  order: 370
+  display_filename: "bstar.gif"
+  mini_filename: "bstar.gif"
+- id: 6
+  code: "pheart"
+  title: "Purple Heart"
+  description: "This soldier has selflessly put him self in peril to successfully aid his comrades and in doing so was wounded or killed."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/pheart.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/pheart_.gif"
+  bar: "http://personnel.29th.org/images/awards/pheart.gif"
+  active: true
+  order: 340
+  display_filename: "pheart.gif"
+  mini_filename: "pheart.gif"
+- id: 7
+  code: "dsm"
+  title: "Distinguished Service Medal"
+  description: "Awarded to soldiers who have carried out duty successfully and responsibly. Contributing not only what is expected in the 29th, but who has made contributions above and beyond the expectations of any member in the 29th."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/dsm.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/dsm_.gif"
+  bar: "http://personnel.29th.org/images/awards/dsm.gif"
+  active: true
+  order: 470
+  display_filename: "dsm.gif"
+  mini_filename: "dsm.gif"
+- id: 8
+  code: "gcon"
+  title: "Good Conduct Medal"
+  description: "In addition to performing his duties with a clean record of discipline and exemplary attendance, this soldier's positive attitude and involvement in 29th related activities, other than his drills or staff commitments, has benefited the unit."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/gcon.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/gcon_.gif"
+  bar: "http://personnel.29th.org/images/awards/gcon.gif"
+  active: true
+  order: 215
+  display_filename: "gcon.gif"
+  mini_filename: "gcon.gif"
+- id: 9
+  code: "arcom"
+  title: "Army Commendation Medal"
+  description: "This soldier has maintained composure and made an effective contribution towards his teams victory without necessarily engaging the enemy. This award is for actions of significance not covered by a Bronze or Silver Star."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/acom.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/acom_.gif"
+  bar: "http://personnel.29th.org/images/awards/arcom.gif"
+  active: true
+  order: 360
+  display_filename: "arcom.gif"
+  mini_filename: "arcom.gif"
+- id: 10
+  code: "aocc"
+  title: "Army of Occupation Medal"
+  description: "Served six months of service in the 29th Infantry Division"
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/aocc.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/aocc_.gif"
+  bar: "http://personnel.29th.org/images/awards/aocc.gif"
+  active: true
+  order: 131
+  display_filename: "aocc.gif"
+  mini_filename: "aocc.gif"
+- id: 11
+  code: "eamc"
+  title: "European-African-Middle Eastern Campaign Medal"
+  description: "Only awarded to the participants that win an attack round of an official scrimmage."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/eamc.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/eamc_.gif"
+  bar: "http://personnel.29th.org/images/awards/eamc.gif"
+  active: true
+  order: 290
+  display_filename: "eamc.gif"
+  mini_filename: "eamc.gif"
+- id: 12
+  code: "adef"
+  title: "American Defense Service Medal"
+  description: "Soldier has graduated the 29th ID's Basic Training program"
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/adef.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/adef_.gif"
+  bar: "http://personnel.29th.org/images/awards/adef.gif"
+  active: true
+  order: 100
+  display_filename: "adef.gif"
+  mini_filename: "adef.gif"
+- id: 13
+  code: "french"
+  title: "French Croix de Guerre Medal"
+  description: "Awarded for leadership contributions that greatly benefit the Battalion as a whole."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/french.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/french_.gif"
+  bar: "http://personnel.29th.org/images/awards/french.gif"
+  active: true
+  order: 480
+  display_filename: "french.gif"
+  mini_filename: "french.gif"
+- id: 14
+  code: "m:rifle:dod"
+  title: "Marksman Badge: Rifle (DOD)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DOD"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 15
+  code: "s:rifle:dod"
+  title: "Sharpshooter Badge: Rifle (DOD)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DOD"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 16
+  code: "e:rifle:dod"
+  title: "Expert Badge: Rifle (DOD)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DOD"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 17
+  code: "hdis"
+  title: "Honorably Discharged Badge"
+  description: "Awarded to all Honorably Discharged Retirees"
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/retired.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/retired.gif"
+  bar: ""
+  active: false
+  order: 0
+  display_filename: ""
+  mini_filename: ""
+- id: 18
+  code: "drillsergeant"
+  title: "Drill Sergeant Badge"
+  description: "Unit Drill Sergeant"
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/di.gif"
+  thumbnail: "http://personnel.29th.org/images/awards_boxes/small/di.gif"
+  bar: "http://personnel.29th.org/images/awards/drillsergeant.gif"
+  active: true
+  order: 153
+  display_filename: "drillsergeant.gif"
+  mini_filename: ""
+- id: 19
+  code: "cib1"
+  title: "Combat Infantry Badge, 1st Award"
+  description: "Awarded to a soldier after their 1st scrimmage with another realism unit."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/cib1.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/cib1_.gif"
+  bar: "http://personnel.29th.org/images/awards/cib1.gif"
+  active: true
+  order: 191
+  display_filename: "cib1.gif"
+  mini_filename: ""
+- id: 20
+  code: "cib2"
+  title: "Combat Infantry Badge, 2nd Award"
+  description: "Awarded to a soldier after their 3rd scrimmage with another realism unit."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/cib2.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/cib2_.gif"
+  bar: "http://personnel.29th.org/images/awards/cib2.gif"
+  active: true
+  order: 192
+  display_filename: "cib2.gif"
+  mini_filename: ""
+- id: 21
+  code: "cib3"
+  title: "Combat Infantry Badge, 3rd Award"
+  description: "Awarded to a soldier after their 5th scrimmage with another realism unit"
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/cib3.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/cib3_.gif"
+  bar: "http://personnel.29th.org/images/awards/cib3.gif"
+  active: true
+  order: 193
+  display_filename: "cib3.gif"
+  mini_filename: ""
+- id: 22
+  code: "eib"
+  title: "Expert Infantry Badge"
+  description: "Awarded to men who prove themselves experts in all aspects of Infantry and is required for soldiers to participate in combat."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/eib.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/eib_.gif"
+  bar: "http://personnel.29th.org/images/awards/eib.gif"
+  active: true
+  order: 90
+  display_filename: "eib.gif"
+  mini_filename: ""
+- id: 23
+  code: "trenches"
+  title: "The Trenches Unit Participation"
+  description: "Participated in The Trenches Unit campaign"
+  game: "N/A"
+  image: ""
+  thumbnail: ""
+  bar: "http://personnel.29th.org/images/awards/trenches.gif"
+  active: true
+  order: 111
+  display_filename: "trenches.png"
+  mini_filename: "tt.gif"
+- id: 24
+  code: "battlegrounds"
+  title: "Battlegrounds Unit Participation"
+  description: "Participated in the Battlegrounds Unit campaign"
+  game: "N/A"
+  image: ""
+  thumbnail: ""
+  bar: "http://personnel.29th.org/images/awards/battlegrounds.gif"
+  active: true
+  order: 112
+  display_filename: "bg.png"
+  mini_filename: "bg.gif"
+- id: 25
+  code: "dod"
+  title: "Day of Defeat Unit Participation"
+  description: "Participated in the Day of Defeat Unit campaign"
+  game: "N/A"
+  image: ""
+  thumbnail: ""
+  bar: "http://personnel.29th.org/images/awards/dod.gif"
+  active: true
+  order: 113
+  display_filename: "dod.png"
+  mini_filename: "dod.gif"
+- id: 26
+  code: "muc"
+  title: "Meritorious Unit Citation"
+  description: "Most exemplary and skilled squad in the company (Transfers every month)"
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/munit.png"
+  thumbnail: "http://personnel.29th.org/images/awards_boxes/small/munit.png"
+  bar: "http://personnel.29th.org/images/awards/muc.gif"
+  active: true
+  order: 120
+  display_filename: "munit.png"
+  mini_filename: "muc.gif"
+- id: 27
+  code: "acamp"
+  title: "American Campaign Medal"
+  description: "Awarded for exemplary leadership on or off the battlefield."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/acamp.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/acamp_.gif"
+  bar: "http://personnel.29th.org/images/awards/acamp.gif"
+  active: true
+  order: 450
+  display_filename: "acamp.gif"
+  mini_filename: "acamp.gif"
+- id: 28
+  code: "cab1"
+  title: "Combat Action Badge, 1st Award"
+  description: "This will be awarded by the Recruitment Officer, to a member of the 29th Infantry Division who has successfully recruited 2 recruits for that week's Training Platoon."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/cab1.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/cab1_.gif"
+  bar: "http://personnel.29th.org/images/awards/cab1.gif"
+  active: true
+  order: 171
+  display_filename: "cab1.gif"
+  mini_filename: ""
+- id: 29
+  code: "cab2"
+  title: "Combat Action Badge, 2nd Award"
+  description: "This will be awarded by the Recruitment Officer, to a member of the 29th Infantry Division who has successfully recruited 5 recruits for that week's Training Platoon."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/cab2.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/cab2_.gif"
+  bar: "http://personnel.29th.org/images/awards/cab2.gif"
+  active: true
+  order: 172
+  display_filename: "cab2.gif"
+  mini_filename: ""
+- id: 30
+  code: "cab3"
+  title: "Combat Action Badge, 3rd Award"
+  description: "This will be awarded by the Recruitment Officer, to a member of the 29th Infantry Division who has successfully recruited 10 recruits for that week's Training Platoon."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/cab3.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/cab3_.gif"
+  bar: "http://personnel.29th.org/images/awards/cab3.gif"
+  active: true
+  order: 173
+  display_filename: "cab3.gif"
+  mini_filename: ""
+- id: 31
+  code: "cab4"
+  title: "Combat Action Badge, 4th Award"
+  description: "This will be awarded by the Recruitment Officer, to a member of the 29th Infantry Division who has successfully recruited 20 recruits for that week's Training Platoon."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/cab4.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/cab4_.gif"
+  bar: "http://personnel.29th.org/images/awards/cab4.gif"
+  active: true
+  order: 174
+  display_filename: "cab4.gif"
+  mini_filename: ""
+- id: 32
+  code: "recruiter"
+  title: "Recruiter Badge"
+  description: "Awarded for exceptional recruiting to the unit."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/recruiter.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/recruiter_.gif"
+  bar: "http://personnel.29th.org/images/awards/recruiter.gif"
+  active: true
+  order: 151
+  display_filename: "recruiter.gif"
+  mini_filename: ""
+- id: 33
+  code: "m:bar:dod"
+  title: "Marksman Badge: Automatic Rifle (DOD)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DOD"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 34
+  code: "s:bar:dod"
+  title: "Sharpshooter Badge: Automatic Rifle (DOD)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DOD"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 35
+  code: "e:bar:dod"
+  title: "Expert Badge: Automatic Rifle (DOD)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DOD"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 36
+  code: "m:mg:dod"
+  title: "Marksman Badge: Machine Gun (DOD)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DOD"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 37
+  code: "s:mg:dod"
+  title: "Sharpshooter Badge: Machine Gun (DOD)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DOD"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 38
+  code: "e:mg:dod"
+  title: "Expert Badge: Machine Gun (DOD)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DOD"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 39
+  code: "m:zook:dod"
+  title: "Marksman Badge: Combat Engineer (DOD)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DOD"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 40
+  code: "s:zook:dod"
+  title: "Sharpshooter Badge: Combat Engineer (DOD)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DOD"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 41
+  code: "e:zook:dod"
+  title: "Expert Badge: Combat Engineer (DOD)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DOD"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 42
+  code: "m:smg:dod"
+  title: "Marksman Badge: Submachine Gun (DOD)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DOD"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 43
+  code: "s:smg:dod"
+  title: "Sharpshooter Badge: Submachine Gun (DOD)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DOD"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 44
+  code: "e:smg:dod"
+  title: "Expert Badge: Submachine Gun (DOD)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DOD"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 45
+  code: "m:rifle:dh"
+  title: "Marksman Badge: Rifle (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 46
+  code: "m:bar:dh"
+  title: "Marksman Badge: Automatic Rifle (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 47
+  code: "m:mg:dh"
+  title: "Marksman Badge: Machine Gun (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 48
+  code: "m:zook:dh"
+  title: "Marksman Badge: Combat Engineer (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 49
+  code: "m:smg:dh"
+  title: "Marksman Badge: Submachine Gun (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 50
+  code: "s:rifle:dh"
+  title: "Sharpshooter Badge: Rifle (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 51
+  code: "s:bar:dh"
+  title: "Sharpshooter Badge: Automatic Rifle (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 52
+  code: "s:mg:dh"
+  title: "Sharpshooter Badge: Machine Gun (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 53
+  code: "s:smg:dh"
+  title: "Sharpshooter Badge: Submachine Gun (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 54
+  code: "s:zook:dh"
+  title: "Sharpshooter Badge: Combat Engineer (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 55
+  code: "e:rifle:dh"
+  title: "Expert Badge: Rifle (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 56
+  code: "e:bar:dh"
+  title: "Expert Badge: Automatic Rifle (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 57
+  code: "e:mg:dh"
+  title: "Expert Badge: Machine Gun (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 58
+  code: "e:smg:dh"
+  title: "Expert Badge: Submachine Gun (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 59
+  code: "e:zook:dh"
+  title: "Expert Badge: Combat Engineer (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 60
+  code: "dh"
+  title: "Darkest Hour Unit Participation"
+  description: "Participated in the Darkest Hour Unit campaign"
+  game: "N/A"
+  image: ""
+  thumbnail: ""
+  bar: "http://personnel.29th.org/images/awards/dh.gif"
+  active: true
+  order: 114
+  display_filename: "dh.png"
+  mini_filename: "dh.gif"
+- id: 61
+  code: "ww1v"
+  title: "World War I Victory Medal"
+  description: "This is to be awarded to members who have served for two years, and for each consecutive two years thereafter."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/ww1v.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/ww1v_.gif"
+  bar: "http://personnel.29th.org/images/awards/ww1v.gif"
+  active: true
+  order: 135
+  display_filename: "ww1v.gif"
+  mini_filename: ""
+- id: 62
+  code: "aach"
+  title: "Army Achievement Award"
+  description: "This soldier has consistently performed his duties in a staff position to the highest calibre and demonstrated the best of non-combat 29th values."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/aach.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/aach_.gif"
+  bar: "http://personnel.29th.org/images/awards/aach.gif"
+  active: true
+  order: 220
+  display_filename: "aach.gif"
+  mini_filename: "aach.gif"
+- id: 63
+  code: "mp"
+  title: "Military Police Badge"
+  description: "Awarded to Military Police Officers"
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/mp.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/mp_.gif"
+  bar: "http://personnel.29th.org/images/awards/mp.gif"
+  active: true
+  order: 155
+  display_filename: "mp.gif"
+  mini_filename: ""
+- id: 64
+  code: "m:armor:dh"
+  title: "Marksman Badge: Armor (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 65
+  code: "s:armor:dh"
+  title: "Sharpshooter Badge: Armor (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 66
+  code: "e:armor:dh"
+  title: "Expert Badge: Armor (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 67
+  code: "m:sniper:dh"
+  title: "Marksman Badge: Sniper (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 68
+  code: "s:sniper:dh"
+  title: "Sharpshooter Badge: Sniper (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 69
+  code: "e:sniper:dh"
+  title: "Expert Badge: Sniper (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 70
+  code: "dms"
+  title: "Defense Meritorious Service Medal"
+  description: "Only awarded to the participants that win a defence round of an official scrimmage.\r\n"
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/dmsm.gif"
+  thumbnail: ""
+  bar: "http://personnel.29th.org/images/awards/dms.gif"
+  active: true
+  order: 280
+  display_filename: "dms.gif"
+  mini_filename: ""
+- id: 71
+  code: "ww2v"
+  title: "World War II (WWII) Victory Medal"
+  description: "Only awarded to the participants that win every round of a multi-round official scrimmage. Awarding of this medal supercedes the awarding of the African European Middle-Eastern Campaign Medal and the Defence Meritorious Service Medal Ribbon."
+  game: "N/A"
+  image: "http://i.imgur.com/6Etx8.png"
+  thumbnail: ""
+  bar: "http://personnel.29th.org/images/awards/ww2v.gif"
+  active: true
+  order: 270
+  display_filename: "ww2v.gif"
+  mini_filename: "ww2v.gif"
+- id: 72
+  code: "m:mortar:dh"
+  title: "Marksman Badge: Mortar (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 73
+  code: "s:mortar:dh"
+  title: "Sharpshooter Badge: Mortar (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 74
+  code: "e:mortar:dh"
+  title: "Expert Badge: Mortar (DH)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "DH"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 75
+  code: "m:rifle:ro2"
+  title: "Marksman Badge: Rifle (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 76
+  code: "s:rifle:ro2"
+  title: "Sharpshooter Badge: Rifle (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 77
+  code: "e:rifle:ro2"
+  title: "Expert Badge: Rifle (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 78
+  code: "m:smg:ro2"
+  title: "Marksman Badge: Submachine Gun (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 79
+  code: "s:smg:ro2"
+  title: "Sharpshooter Badge: Submachine Gun (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 80
+  code: "e:smg:ro2"
+  title: "Expert Badge: Submachine Gun (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 81
+  code: "m:bar:ro2"
+  title: "Marksman Badge: Automatic Rifle (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 82
+  code: "s:bar:ro2"
+  title: "Sharpshooter Badge: Automatic Rifle (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 83
+  code: "e:bar:ro2"
+  title: "Expert Badge: Automatic Rifle (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 84
+  code: "m:mg:ro2"
+  title: "Marksman Badge: Machine Gun (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 85
+  code: "s:mg:ro2"
+  title: "Sharpshooter Badge: Machine Gun (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 86
+  code: "e:mg:ro2"
+  title: "Expert Badge: Machine Gun (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 87
+  code: "m:zook:ro2"
+  title: "Marksman Badge: Combat Engineer (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 88
+  code: "s:zook:ro2"
+  title: "Sharpshooter Badge: Combat Engineer (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 89
+  code: "e:zook:ro2"
+  title: "Expert Badge: Combat Engineer (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 90
+  code: "s:sniper:ro2"
+  title: "Sharpshooter Badge: Sniper (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 91
+  code: "m:sniper:ro2"
+  title: "Marksman Badge: Sniper (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 92
+  code: "e:sniper:ro2"
+  title: "Expert Badge: Sniper (RO2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 93
+  code: "m:rifle:a3"
+  title: "Marksman Badge: Rifle (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 94
+  code: "s:rifle:a3"
+  title: "Sharpshooter Badge: Rifle (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 95
+  code: "m:bar:a3"
+  title: "Marksman Badge: Automatic Rifle (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 96
+  code: "e:rifle:a3"
+  title: "Expert Badge: Rifle (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 97
+  code: "s:bar:a3"
+  title: "Sharpshooter Badge: Automatic Rifle (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 98
+  code: "e:bar:a3"
+  title: "Expert Badge: Automatic Rifle (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 99
+  code: "m:mg:a3"
+  title: "Marksman Badge: Machine Gun (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 100
+  code: "s:mg:a3"
+  title: "Sharpshooter Badge: Machine Gun (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 101
+  code: "e:mg:a3"
+  title: "Expert Badge: Machine Gun (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 102
+  code: "s:sniper:a3"
+  title: "Sharpshooter Badge: Sniper (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 103
+  code: "m:sniper:a3"
+  title: "Marksman Badge: Sniper (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 104
+  code: "e:sniper:a3"
+  title: "Expert Badge: Sniper (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 105
+  code: "m:armor:a3"
+  title: "Marksman Badge: Armor (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 106
+  code: "s:armor:a3"
+  title: "Sharpshooter Badge: Armor (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 107
+  code: "e:armor:a3"
+  title: "Expert Badge: Armor (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 108
+  code: "rs"
+  title: "Rising Storm Unit Participation"
+  description: "Participated in the Rising Storm Unit campaign"
+  game: "N/A"
+  image: ""
+  thumbnail: ""
+  bar: "http://personnel.29th.org/images/awards/rs.gif"
+  active: true
+  order: 115
+  display_filename: "rs.png"
+  mini_filename: "rs.gif"
+- id: 109
+  code: "arma"
+  title: "ARMA Unit Participation"
+  description: "Participated in the ARMA Unit campaign"
+  game: "N/A"
+  image: ""
+  thumbnail: ""
+  bar: "http://personnel.29th.org/images/awards/arma.gif"
+  active: true
+  order: 116
+  display_filename: ""
+  mini_filename: "arma.gif"
+- id: 110
+  code: "rd"
+  title: "Ruptured Duck"
+  description: "For Honourably Discharged members."
+  game: "N/A"
+  image: ""
+  thumbnail: ""
+  bar: ""
+  active: false
+  order: 0
+  display_filename: ""
+  mini_filename: ""
+- id: 111
+  code: "anpdr"
+  title: "Army NCO Professional Development Ribbon"
+  description: "This soldier has passed through a Squad Leader Training Program."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/anpdr.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/anpdr_.gif"
+  bar: "http://personnel.29th.org/images/awards/anpdr.gif"
+  active: true
+  order: 410
+  display_filename: "anpdr.gif"
+  mini_filename: "anpdr.gif"
+- id: 112
+  code: "movsm"
+  title: "Military Outstanding Volunteer Service Medal"
+  description: "This soldier has been a major contributor to a large, important and successfully project in a staff office."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/movsm.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/movsm_.gif"
+  bar: "http://personnel.29th.org/images/awards/movsm.gif"
+  active: true
+  order: 230
+  display_filename: "movsm.gif"
+  mini_filename: "movsm.gif"
+- id: 113
+  code: "arcam"
+  title: "Army Reserve Components Achievement Medal"
+  description: "In addition to diligence and success in staff duties, this soldier's positive attitude and involvement in other 29th related activities has benefited the unit."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/arcam.gif"
+  thumbnail: "http://personnel.29th.org/images/awards/arcam_.gif"
+  bar: "http://personnel.29th.org/images/awards/arcam.gif"
+  active: false
+  order: 210
+  display_filename: "arcam.gif"
+  mini_filename: "arcam.gif"
+- id: 114
+  code: "m:smg:a3"
+  title: "Marksman Badge: SMG (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 115
+  code: "s:smg:a3"
+  title: "Sharpshooter Badge: SMG (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 116
+  code: "e:smg:a3"
+  title: "Expert Badge: SMG (A3)  "
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 117
+  code: "m:zook:a3"
+  title: "Marksman Badge: Combat Engineer (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 118
+  code: "s:zook:a3"
+  title: "Sharpshooter Badge: Combat Engineer (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 119
+  code: "e:zook:a3"
+  title: "Expert Badge: Combat Engineer (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 120
+  code: "m:pilot:a3"
+  title: "Marksman Badge: Pilot (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/wingsMark.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/wingsMark.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 121
+  code: "s:pilot:a3"
+  title: "Sharpshooter Badge: Pilot (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/wingsSharp.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/wingsSharp.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 122
+  code: "e:pilot:a3"
+  title: "Expert Badge: Pilot (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/wingsExpert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/wingsExpert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 123
+  code: "m:grenadier:a3"
+  title: "Marksman Badge: Grenadier (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 124
+  code: "s:grenadier:a3"
+  title: "Sharpshooter Badge: Grenadier (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 125
+  code: "e:grenadier:a3"
+  title: "Expert Badge: Grenadier (A3)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Arma 3"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 126
+  code: "m:armor:rs"
+  title: "Marksman Badge: Armor (RS)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 127
+  code: "s:armor:rs"
+  title: "Sharpshooter Badge: Armor (RS)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 128
+  code: "e:armor:rs"
+  title: "Expert Badge: Armor (RS)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 129
+  code: "afem"
+  title: "Armed Forces Expeditionary Medal"
+  description: "Awarded for participation in a non-official scrimmage event. Does not apply to public scrimmages. Must be private events that are organized and have a limited, selected roster of participants from 29th."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/afem.png"
+  thumbnail: "http://personnel.29th.org/images/awards_boxes/small/afem.png"
+  bar: "http://personnel.29th.org/images/awards/afem.gif"
+  active: true
+  order: 208
+  display_filename: "afem.png"
+  mini_filename: ""
+- id: 130
+  code: "afsm"
+  title: "Armed Forces Service Medal"
+  description: "For Soldiers whom perform staff related duties above and beyond what is required in a staff position."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/afsm.png"
+  thumbnail: "http://personnel.29th.org/images/awards_boxes/small/afsm.png"
+  bar: "http://personnel.29th.org/images/awards/afsm.gif"
+  active: true
+  order: 207
+  display_filename: "afsm.png"
+  mini_filename: ""
+- id: 131
+  code: "msm"
+  title: "Meritorious Service Medal"
+  description: "Awarded for Service in the 29th that is exemplary as a solid soldier whom has aided and put forth the time and effort to the 29th when asked and not asked."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/msm.png"
+  thumbnail: "http://personnel.29th.org/images/awards_boxes/small/msm.png"
+  bar: "http://personnel.29th.org/images/awards/msm.gif"
+  active: true
+  order: 206
+  display_filename: "msm.png"
+  mini_filename: ""
+- id: 132
+  code: "suc"
+  title: "Superior Unit Citation"
+  description: "Squad excels among all squads at a platoon level. Platoon HQ can award two Superior Citations a year (reviewed every six months). "
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/sunit.png"
+  thumbnail: "http://personnel.29th.org/images/awards_boxes/small/sunit.png"
+  bar: "http://personnel.29th.org/images/awards/suc.gif"
+  active: true
+  order: 119
+  display_filename: "sunit.png"
+  mini_filename: ""
+- id: 133
+  code: "mpsm"
+  title: "Meritorious Public Service Medal"
+  description: "Awarded in recognition of dedication through recurring financial contributions to the upkeep of the unit. Requires minimum contribution for recurring donation system. This medal remains on a members jacket only during active periods of contribution."
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/mpsm.gif"
+  thumbnail: "http://personnel.29th.org/images/awards_boxes/small/mpsm.gif"
+  bar: "http://personnel.29th.org/images/awards/mpsm.gif"
+  active: true
+  order: 204
+  display_filename: "mpsm.gif"
+  mini_filename: ""
+- id: 134
+  code: "m:rifle:rs2"
+  title: "Marksman Badge: Rifle (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 135
+  code: "s:rifle:rs2"
+  title: "Sharpshooter Badge: Rifle (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 136
+  code: "e:rifle:rs2"
+  title: "Expert Badge: Rifle (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 137
+  code: "m:rifle:sq"
+  title: "Marksman Badge: Rifle (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 138
+  code: "s:rifle:sq"
+  title: "Sharpshooter Badge: Rifle (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 139
+  code: "e:rifle:sq"
+  title: "Expert Badge: Rifle (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 140
+  code: "rs2"
+  title: "Rising Storm 2 Unit Participation"
+  description: "Participated in the Rising Storm 2: Vietnam Unit campaign"
+  game: "N/A"
+  image: ""
+  thumbnail: ""
+  bar: "http://personnel.29th.org//images/awards/rs2.gif"
+  active: true
+  order: 117
+  display_filename: ""
+  mini_filename: "rs2.gif"
+- id: 141
+  code: "sq"
+  title: "Squad Unit Participation"
+  description: "Participated in the Squad Unit campaign"
+  game: "N/A"
+  image: ""
+  thumbnail: ""
+  bar: "http://personnel.29th.org//images/awards/sq.gif"
+  active: true
+  order: 118
+  display_filename: ""
+  mini_filename: "sq.gif"
+- id: 142
+  code: "m:smg:rs2"
+  title: "Marksman Badge: Submachine Gun (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 143
+  code: "s:smg:rs2"
+  title: "Sharpshooter Badge: Submachine Gun (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 144
+  code: "e:smg:rs2"
+  title: "Expert Badge: Submachine Gun (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge    "
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 145
+  code: "m:mg:rs2"
+  title: "Marksman Badge: Machine Gun (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 146
+  code: "s:mg:rs2"
+  title: "Sharpshooter Badge: Machine Gun (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 147
+  code: "e:mg:rs2"
+  title: "Expert Badge: Machine Gun (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 148
+  code: "m:zook:rs2"
+  title: "Marksman Badge: Combat Engineer (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 149
+  code: "s:zook:rs2"
+  title: "Sharpshooter Badge: Combat Engineer (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 150
+  code: "e:zook:rs2"
+  title: "Expert Badge: Combat Engineer (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 151
+  code: "m:sniper:rs2"
+  title: "Marksman Badge: Sniper (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge    "
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 152
+  code: "s:sniper:rs2"
+  title: "Sharpshooter Badge: Sniper (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 153
+  code: "e:sniper:rs2"
+  title: "Expert Badge: Sniper (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 154
+  code: "m:grenadier:rs2"
+  title: "Marksman Badge: Grenadier (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 155
+  code: "s:grenadier:rs2"
+  title: "Sharpshooter Badge: Grenadier (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 156
+  code: "e:grenadier:rs2"
+  title: "Expert Badge: Grenadier (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 157
+  code: "m:grenadier:sq"
+  title: "Marksman Badge: Grenadier (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 158
+  code: "s:grenadier:sq"
+  title: "Sharpshooter Badge: Grenadier (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 159
+  code: "e:grenadier:sq"
+  title: "Expert Badge: Grenadier (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 160
+  code: "m:zook:sq"
+  title: "Marksman Badge: Combat Engineer (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 161
+  code: "s:zook:sq"
+  title: "Sharpshooter Badge: Combat Engineer (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 162
+  code: "e:zook:sq"
+  title: "Expert Badge: Combat Engineer (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 163
+  code: "m:bar:sq"
+  title: "Marksman Badge: Automatic Rifle (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 164
+  code: "s:bar:sq"
+  title: "Sharpshooter Badge: Automatic Rifle (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 165
+  code: "e:bar:sq"
+  title: "Expert Badge: Automatic Rifle (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 166
+  code: "m:sniper:sq"
+  title: "Marksman Badge: Sniper (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 167
+  code: "s:sniper:sq"
+  title: "Sharpshooter Badge: Sniper (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 168
+  code: "e:sniper:sq"
+  title: "Expert Badge: Sniper (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 169
+  code: "m:armor:sq"
+  title: "Marksman Badge: Armor (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/marksman.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 170
+  code: "s:armor:sq"
+  title: "Sharpshooter Badge: Armor (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/sharpshooter.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 171
+  code: "e:armor:sq"
+  title: "Expert Badge: Armor (SQ)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "Squad"
+  image: "http://personnel.29th.org/images/badges/web/expert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/expert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 172
+  code: "m:pilot:rs2"
+  title: "Marksman Badge: Pilot (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/wingsMark.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/wingsMark.gif"
+  bar: "http://personnel.29th.org/images/awards/marks.gif"
+  active: true
+  order: 0
+  display_filename: "marks.gif"
+  mini_filename: "marks.gif"
+- id: 173
+  code: "s:pilot:rs2"
+  title: "Sharpshooter Badge: Pilot (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/wingsSharp.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/wingsSharp.gif"
+  bar: "http://personnel.29th.org/images/awards/sharps.gif"
+  active: true
+  order: 0
+  display_filename: "sharps.gif"
+  mini_filename: "sharps.gif"
+- id: 174
+  code: "e:pilot:rs2"
+  title: "Expert Badge: Pilot (RS2)"
+  description: "Meets all AIT standards of qualification designated for this badge"
+  game: "RS2"
+  image: "http://personnel.29th.org/images/badges/web/wingsExpert.gif"
+  thumbnail: "http://personnel.29th.org/images/badges/web/wingsExpert.gif"
+  bar: "http://personnel.29th.org/images/awards/expert.gif"
+  active: true
+  order: 0
+  display_filename: "expert.gif"
+  mini_filename: "expert.gif"
+- id: 175
+  code: "bicord"
+  title: "Blue Infantry Cord"
+  description: "Awarded for a $10 Recurring Donation"
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/bicord.png"
+  thumbnail: "http://personnel.29th.org/images/awards/bicord.png"
+  bar: "http://personnel.29th.org/images/awards/bicord.png"
+  active: true
+  order: 0
+  display_filename: ""
+  mini_filename: ""
+- id: 176
+  code: "suc_2"
+  title: "Superior Unit Citation (previous)"
+  description: "Squad excels among all squads at a platoon level. Platoon HQ can award two Superior Citations a year (reviewed every six months). "
+  game: "N/A"
+  image: "http://personnel.29th.org/images/awards_boxes/large/sunit.png"
+  thumbnail: "http://personnel.29th.org/images/awards_boxes/small/sunit.png"
+  bar: "http://personnel.29th.org/images/awards/suc.gif"
+  active: false
+  order: 119
+  display_filename: "sunit.png"
+  mini_filename: ""
+- id: 177
+  code: "ordinstructor"
+  title: "Ordnance Instructor Badge"
+  description: "Unit Ordnance Instructor"
+  game: "Squad"
+  image: ""
+  thumbnail: ""
+  bar: ""
+  active: true
+  order: 154
+  display_filename: null
+  mini_filename: null

--- a/db/seeds/data/countries.yml
+++ b/db/seeds/data/countries.yml
@@ -1,0 +1,720 @@
+- id: 1
+  abbr: "AD"
+  name: "Andorra"
+- id: 2
+  abbr: "AE"
+  name: "United Arab Emirates"
+- id: 3
+  abbr: "AF"
+  name: "Afghanistan"
+- id: 4
+  abbr: "AG"
+  name: "Antigua and Barbuda"
+- id: 5
+  abbr: "AI"
+  name: "Anguilla"
+- id: 6
+  abbr: "AL"
+  name: "Albania"
+- id: 7
+  abbr: "AM"
+  name: "Armenia"
+- id: 8
+  abbr: "AN"
+  name: "Netherlands Antilles"
+- id: 9
+  abbr: "AO"
+  name: "Angola"
+- id: 10
+  abbr: "AQ"
+  name: "Antarctica"
+- id: 11
+  abbr: "AR"
+  name: "Argentina"
+- id: 12
+  abbr: "AS"
+  name: "American Samoa"
+- id: 13
+  abbr: "AT"
+  name: "Austria"
+- id: 14
+  abbr: "AU"
+  name: "Australia"
+- id: 15
+  abbr: "AW"
+  name: "Aruba"
+- id: 16
+  abbr: "AZ"
+  name: "Azerbaijan"
+- id: 17
+  abbr: "BA"
+  name: "Bosnia and Herzegovina"
+- id: 18
+  abbr: "BB"
+  name: "Barbados"
+- id: 19
+  abbr: "BD"
+  name: "Bangladesh"
+- id: 20
+  abbr: "BE"
+  name: "Belgium"
+- id: 21
+  abbr: "BF"
+  name: "Burkina Faso"
+- id: 22
+  abbr: "BG"
+  name: "Bulgaria"
+- id: 23
+  abbr: "BH"
+  name: "Bahrain"
+- id: 24
+  abbr: "BI"
+  name: "Burundi"
+- id: 25
+  abbr: "BJ"
+  name: "Benin"
+- id: 26
+  abbr: "BM"
+  name: "Bermuda"
+- id: 27
+  abbr: "BN"
+  name: "Brunei Darussalam"
+- id: 28
+  abbr: "BO"
+  name: "Bolivia"
+- id: 29
+  abbr: "BR"
+  name: "Brazil"
+- id: 30
+  abbr: "BS"
+  name: "Bahamas"
+- id: 31
+  abbr: "BT"
+  name: "Bhutan"
+- id: 32
+  abbr: "BV"
+  name: "Bouvet Island"
+- id: 33
+  abbr: "BW"
+  name: "Botswana"
+- id: 34
+  abbr: "BY"
+  name: "Belarus"
+- id: 35
+  abbr: "BZ"
+  name: "Belize"
+- id: 36
+  abbr: "CA"
+  name: "Canada"
+- id: 37
+  abbr: "CC"
+  name: "Cocos (Keeling) Islands"
+- id: 38
+  abbr: "CD"
+  name: "Congo, The Democratic Republic of the"
+- id: 39
+  abbr: "CF"
+  name: "Central African Republic"
+- id: 40
+  abbr: "CG"
+  name: "Congo"
+- id: 41
+  abbr: "CH"
+  name: "Switzerland"
+- id: 42
+  abbr: "CI"
+  name: "Cote d'Ivoire"
+- id: 43
+  abbr: "CK"
+  name: "Cook Islands"
+- id: 44
+  abbr: "CL"
+  name: "Chile"
+- id: 45
+  abbr: "CM"
+  name: "Cameroon"
+- id: 46
+  abbr: "CN"
+  name: "China"
+- id: 47
+  abbr: "CO"
+  name: "Colombia"
+- id: 48
+  abbr: "CR"
+  name: "Costa Rica"
+- id: 49
+  abbr: "RS"
+  name: "Serbia"
+- id: 50
+  abbr: "CU"
+  name: "Cuba"
+- id: 51
+  abbr: "CV"
+  name: "Cape Verde"
+- id: 52
+  abbr: "CX"
+  name: "Christmas Island"
+- id: 53
+  abbr: "CY"
+  name: "Cyprus"
+- id: 54
+  abbr: "CZ"
+  name: "Czech Republic"
+- id: 55
+  abbr: "DE"
+  name: "Germany"
+- id: 56
+  abbr: "DJ"
+  name: "Djibouti"
+- id: 57
+  abbr: "DK"
+  name: "Denmark"
+- id: 58
+  abbr: "DM"
+  name: "Dominica"
+- id: 59
+  abbr: "DO"
+  name: "Dominican Republic"
+- id: 60
+  abbr: "DZ"
+  name: "Algeria"
+- id: 61
+  abbr: "EC"
+  name: "Ecuador"
+- id: 62
+  abbr: "EE"
+  name: "Estonia"
+- id: 63
+  abbr: "EG"
+  name: "Egypt"
+- id: 64
+  abbr: "EH"
+  name: "Western Sahara"
+- id: 65
+  abbr: "ER"
+  name: "Eritrea"
+- id: 66
+  abbr: "ES"
+  name: "Spain"
+- id: 67
+  abbr: "ET"
+  name: "Ethiopia"
+- id: 68
+  abbr: "FI"
+  name: "Finland"
+- id: 69
+  abbr: "FJ"
+  name: "Fiji"
+- id: 70
+  abbr: "FK"
+  name: "Falkland Islands (Malvinas)"
+- id: 71
+  abbr: "FM"
+  name: "Micronesia, Federated States of"
+- id: 72
+  abbr: "FO"
+  name: "Faroe Islands"
+- id: 73
+  abbr: "FR"
+  name: "France"
+- id: 74
+  abbr: "GA"
+  name: "Gabon"
+- id: 75
+  abbr: "GB"
+  name: "United Kingdom"
+- id: 76
+  abbr: "GD"
+  name: "Grenada"
+- id: 77
+  abbr: "GE"
+  name: "Georgia"
+- id: 78
+  abbr: "GF"
+  name: "French Guiana"
+- id: 79
+  abbr: "GH"
+  name: "Ghana"
+- id: 80
+  abbr: "GI"
+  name: "Gibraltar"
+- id: 81
+  abbr: "GL"
+  name: "Greenland"
+- id: 82
+  abbr: "GM"
+  name: "Gambia"
+- id: 83
+  abbr: "GN"
+  name: "Guinea"
+- id: 84
+  abbr: "GP"
+  name: "Guadeloupe"
+- id: 85
+  abbr: "GQ"
+  name: "Equatorial Guinea"
+- id: 86
+  abbr: "GR"
+  name: "Greece"
+- id: 87
+  abbr: "GS"
+  name: "South Georgia and the South Sandwich Islands"
+- id: 88
+  abbr: "GT"
+  name: "Guatemala"
+- id: 89
+  abbr: "GU"
+  name: "Guam"
+- id: 90
+  abbr: "GW"
+  name: "Guinea-bissau"
+- id: 91
+  abbr: "GY"
+  name: "Guyana"
+- id: 92
+  abbr: "HK"
+  name: "Hong Kong"
+- id: 93
+  abbr: "HM"
+  name: "Heard Island and McDonald Islands"
+- id: 94
+  abbr: "HN"
+  name: "Honduras"
+- id: 95
+  abbr: "HR"
+  name: "Croatia"
+- id: 96
+  abbr: "HT"
+  name: "Haiti"
+- id: 97
+  abbr: "HU"
+  name: "Hungary"
+- id: 98
+  abbr: "ID"
+  name: "Indonesia"
+- id: 99
+  abbr: "IE"
+  name: "Ireland"
+- id: 100
+  abbr: "IL"
+  name: "Israel"
+- id: 101
+  abbr: "IN"
+  name: "India"
+- id: 102
+  abbr: "IO"
+  name: "British Indian Ocean Territory"
+- id: 103
+  abbr: "IQ"
+  name: "Iraq"
+- id: 104
+  abbr: "IR"
+  name: "Iran, Islamic Republic of"
+- id: 105
+  abbr: "IS"
+  name: "Iceland"
+- id: 106
+  abbr: "IT"
+  name: "Italy"
+- id: 107
+  abbr: "JM"
+  name: "Jamaica"
+- id: 108
+  abbr: "JO"
+  name: "Jordan"
+- id: 109
+  abbr: "JP"
+  name: "Japan"
+- id: 110
+  abbr: "KE"
+  name: "Kenya"
+- id: 111
+  abbr: "KG"
+  name: "Kyrgyzstan"
+- id: 112
+  abbr: "KH"
+  name: "Cambodia"
+- id: 113
+  abbr: "KI"
+  name: "Kiribati"
+- id: 114
+  abbr: "KM"
+  name: "Comoros"
+- id: 115
+  abbr: "KN"
+  name: "Saint Kitts and Nevis"
+- id: 116
+  abbr: "KP"
+  name: "Korea, Democratic People's Republic of"
+- id: 117
+  abbr: "KR"
+  name: "Korea, Republic of"
+- id: 118
+  abbr: "KW"
+  name: "Kuwait"
+- id: 119
+  abbr: "KY"
+  name: "Cayman Islands"
+- id: 120
+  abbr: "KZ"
+  name: "Kazakhstan"
+- id: 121
+  abbr: "LA"
+  name: "Lao People's Democratic Republic"
+- id: 122
+  abbr: "LB"
+  name: "Lebanon"
+- id: 123
+  abbr: "LC"
+  name: "Saint Lucia"
+- id: 124
+  abbr: "LI"
+  name: "Liechtenstein"
+- id: 125
+  abbr: "LK"
+  name: "Sri Lanka"
+- id: 126
+  abbr: "LR"
+  name: "Liberia"
+- id: 127
+  abbr: "LS"
+  name: "Lesotho"
+- id: 128
+  abbr: "LT"
+  name: "Lithuania"
+- id: 129
+  abbr: "LU"
+  name: "Luxembourg"
+- id: 130
+  abbr: "LV"
+  name: "Latvia"
+- id: 131
+  abbr: "LY"
+  name: "Libyan Arab Jamahiriya"
+- id: 132
+  abbr: "MA"
+  name: "Morocco"
+- id: 133
+  abbr: "MC"
+  name: "Monaco"
+- id: 134
+  abbr: "MD"
+  name: "Moldova, Republic of"
+- id: 135
+  abbr: "MG"
+  name: "Madagascar"
+- id: 136
+  abbr: "MH"
+  name: "Marshall Islands"
+- id: 137
+  abbr: "MK"
+  name: "Macedonia, the Former Yugoslav Republic of"
+- id: 138
+  abbr: "ML"
+  name: "Mali"
+- id: 139
+  abbr: "MM"
+  name: "Myanmar"
+- id: 140
+  abbr: "MN"
+  name: "Mongolia"
+- id: 141
+  abbr: "MO"
+  name: "Macao"
+- id: 142
+  abbr: "MP"
+  name: "Northern Mariana Islands"
+- id: 143
+  abbr: "MQ"
+  name: "Martinique"
+- id: 144
+  abbr: "MR"
+  name: "Mauritania"
+- id: 145
+  abbr: "MS"
+  name: "Montserrat"
+- id: 146
+  abbr: "MT"
+  name: "Malta"
+- id: 147
+  abbr: "MU"
+  name: "Mauritius"
+- id: 148
+  abbr: "MV"
+  name: "Maldives"
+- id: 149
+  abbr: "MW"
+  name: "Malawi"
+- id: 150
+  abbr: "MX"
+  name: "Mexico"
+- id: 151
+  abbr: "MY"
+  name: "Malaysia"
+- id: 152
+  abbr: "MZ"
+  name: "Mozambique"
+- id: 153
+  abbr: "NA"
+  name: "Namibia"
+- id: 154
+  abbr: "NC"
+  name: "New Caledonia"
+- id: 155
+  abbr: "NE"
+  name: "Niger"
+- id: 156
+  abbr: "NF"
+  name: "Norfolk Island"
+- id: 157
+  abbr: "NG"
+  name: "Nigeria"
+- id: 158
+  abbr: "NI"
+  name: "Nicaragua"
+- id: 159
+  abbr: "NL"
+  name: "Netherlands"
+- id: 160
+  abbr: "NO"
+  name: "Norway"
+- id: 161
+  abbr: "NP"
+  name: "Nepal"
+- id: 162
+  abbr: "NR"
+  name: "Nauru"
+- id: 163
+  abbr: "NU"
+  name: "Niue"
+- id: 164
+  abbr: "NZ"
+  name: "New Zealand"
+- id: 165
+  abbr: "OM"
+  name: "Oman"
+- id: 166
+  abbr: "PA"
+  name: "Panama"
+- id: 167
+  abbr: "PE"
+  name: "Peru"
+- id: 168
+  abbr: "PF"
+  name: "French Polynesia"
+- id: 169
+  abbr: "PG"
+  name: "Papua New Guinea"
+- id: 170
+  abbr: "PH"
+  name: "Philippines"
+- id: 171
+  abbr: "PK"
+  name: "Pakistan"
+- id: 172
+  abbr: "PL"
+  name: "Poland"
+- id: 173
+  abbr: "PM"
+  name: "Saint Pierre and Miquelon"
+- id: 174
+  abbr: "PN"
+  name: "Pitcairn"
+- id: 175
+  abbr: "PR"
+  name: "Puerto Rico"
+- id: 176
+  abbr: "PS"
+  name: "Palestinian Territory, Occupied"
+- id: 177
+  abbr: "PT"
+  name: "Portugal"
+- id: 178
+  abbr: "PW"
+  name: "Palau"
+- id: 179
+  abbr: "PY"
+  name: "Paraguay"
+- id: 180
+  abbr: "QA"
+  name: "Qatar"
+- id: 181
+  abbr: "RE"
+  name: "Reunion"
+- id: 182
+  abbr: "RO"
+  name: "Romania"
+- id: 183
+  abbr: "RU"
+  name: "Russian Federation"
+- id: 184
+  abbr: "RW"
+  name: "Rwanda"
+- id: 185
+  abbr: "SA"
+  name: "Saudi Arabia"
+- id: 186
+  abbr: "SB"
+  name: "Solomon Islands"
+- id: 187
+  abbr: "SC"
+  name: "Seychelles"
+- id: 188
+  abbr: "SD"
+  name: "Sudan"
+- id: 189
+  abbr: "SE"
+  name: "Sweden"
+- id: 190
+  abbr: "SG"
+  name: "Singapore"
+- id: 191
+  abbr: "SH"
+  name: "Saint Helena"
+- id: 192
+  abbr: "SI"
+  name: "Slovenia"
+- id: 193
+  abbr: "SJ"
+  name: "Svalbard and Jan Mayen"
+- id: 194
+  abbr: "SK"
+  name: "Slovakia"
+- id: 195
+  abbr: "SL"
+  name: "Sierra Leone"
+- id: 196
+  abbr: "SM"
+  name: "San Marino"
+- id: 197
+  abbr: "SN"
+  name: "Senegal"
+- id: 198
+  abbr: "SO"
+  name: "Somalia"
+- id: 199
+  abbr: "SR"
+  name: "Suriname"
+- id: 200
+  abbr: "ST"
+  name: "Sao Tome and Principe"
+- id: 201
+  abbr: "SV"
+  name: "El Salvador"
+- id: 202
+  abbr: "SY"
+  name: "Syrian Arab Republic"
+- id: 203
+  abbr: "SZ"
+  name: "Swaziland"
+- id: 204
+  abbr: "TC"
+  name: "Turks and Caicos Islands"
+- id: 205
+  abbr: "TD"
+  name: "Chad"
+- id: 206
+  abbr: "TF"
+  name: "French Southern Territories"
+- id: 207
+  abbr: "TG"
+  name: "Togo"
+- id: 208
+  abbr: "TH"
+  name: "Thailand"
+- id: 209
+  abbr: "TJ"
+  name: "Tajikistan"
+- id: 210
+  abbr: "TK"
+  name: "Tokelau"
+- id: 211
+  abbr: "TL"
+  name: "Timor-leste"
+- id: 212
+  abbr: "TM"
+  name: "Turkmenistan"
+- id: 213
+  abbr: "TN"
+  name: "Tunisia"
+- id: 214
+  abbr: "TO"
+  name: "Tonga"
+- id: 215
+  abbr: "TR"
+  name: "Turkey"
+- id: 216
+  abbr: "TT"
+  name: "Trinidad and Tobago"
+- id: 217
+  abbr: "TV"
+  name: "Tuvalu"
+- id: 218
+  abbr: "TW"
+  name: "Taiwan"
+- id: 219
+  abbr: "TZ"
+  name: "Tanzania, United Republic of"
+- id: 220
+  abbr: "UA"
+  name: "Ukraine"
+- id: 221
+  abbr: "UG"
+  name: "Uganda"
+- id: 222
+  abbr: "UM"
+  name: "United States Minor Outlying Islands"
+- id: 223
+  abbr: "US"
+  name: "United States"
+- id: 224
+  abbr: "UY"
+  name: "Uruguay"
+- id: 225
+  abbr: "UZ"
+  name: "Uzbekistan"
+- id: 226
+  abbr: "VA"
+  name: "Vatican City State"
+- id: 227
+  abbr: "VC"
+  name: "Saint Vincent and the Grenadines"
+- id: 228
+  abbr: "VE"
+  name: "Venezuela"
+- id: 229
+  abbr: "VG"
+  name: "Virgin Islands, British"
+- id: 230
+  abbr: "VI"
+  name: "Virgin Islands, U.S."
+- id: 231
+  abbr: "VN"
+  name: "Vietnam"
+- id: 232
+  abbr: "VU"
+  name: "Vanuatu"
+- id: 233
+  abbr: "WF"
+  name: "Wallis and Futuna"
+- id: 234
+  abbr: "WS"
+  name: "Samoa"
+- id: 235
+  abbr: "YE"
+  name: "Yemen"
+- id: 236
+  abbr: "YT"
+  name: "Mayotte"
+- id: 237
+  abbr: "ZA"
+  name: "South Africa"
+- id: 238
+  abbr: "ZM"
+  name: "Zambia"
+- id: 239
+  abbr: "ZW"
+  name: "Zimbabwe"
+- id: 240
+  abbr: "ME"
+  name: "Montenegro"

--- a/db/seeds/data/positions.yml
+++ b/db/seeds/data/positions.yml
@@ -1,0 +1,2219 @@
+- id: 1
+  name: "Rifleman"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Rifle"
+- id: 2
+  name: "Second Class Automatic Rifleman"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Automatic Rifle"
+- id: 3
+  name: "First Class Automatic Rifleman"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Automatic Rifle"
+- id: 4
+  name: "Second Class Machine Gunner"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Machine Gun"
+- id: 5
+  name: "First Class Machine Gunner"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Machine Gun"
+- id: 6
+  name: "Combat Engineer"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Combat Engineer"
+- id: 7
+  name: "Submachine Gunner"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Submachine Gun"
+- id: 8
+  name: "Tanker"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Armor"
+- id: 9
+  name: "Mortarman"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Mortar"
+- id: 10
+  name: "Asst. Squad Leader"
+  active: true
+  order: 8
+  description: ""
+  access_level: 10
+  AIT: "Leadership"
+- id: 11
+  name: "Squad Leader"
+  active: true
+  order: 9
+  description: ""
+  access_level: 10
+  AIT: "Leadership"
+- id: 12
+  name: "Platoon Clerk"
+  active: true
+  order: 10
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 13
+  name: "Platoon Sniper"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Sniper"
+- id: 14
+  name: "Platoon Sergeant"
+  active: true
+  order: 18
+  description: ""
+  access_level: 10
+  AIT: "Leadership"
+- id: 15
+  name: "Platoon Leader"
+  active: true
+  order: 69
+  description: ""
+  access_level: 10
+  AIT: "Leadership"
+- id: 16
+  name: "Drill Instructor"
+  active: true
+  order: 68
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 17
+  name: "Company Clerk"
+  active: true
+  order: 0
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 18
+  name: "Company Sergeant"
+  active: true
+  order: 36
+  description: ""
+  access_level: 10
+  AIT: "Leadership"
+- id: 19
+  name: "Senior NCO"
+  active: true
+  order: 37
+  description: ""
+  access_level: 10
+  AIT: "Leadership"
+- id: 20
+  name: "Commanding Officer"
+  active: true
+  order: 39
+  description: ""
+  access_level: 10
+  AIT: "Leadership"
+- id: 21
+  name: "Battalion SNCO"
+  active: true
+  order: 80
+  description: ""
+  access_level: 10
+  AIT: "Leadership"
+- id: 22
+  name: "Battalion Executive Officer"
+  active: true
+  order: 96
+  description: ""
+  access_level: 10
+  AIT: "Leadership"
+- id: 23
+  name: "Battalion Commander"
+  active: true
+  order: 99
+  description: ""
+  access_level: 10
+  AIT: "Leadership"
+- id: 24
+  name: "Executive Officer"
+  active: true
+  order: 38
+  description: ""
+  access_level: 10
+  AIT: "Leadership"
+- id: 25
+  name: "Chief of Engineer Corps"
+  active: true
+  order: 99
+  description: "Responsible for guiding, invention, and overseeing of engineer projects.  Responsible for making sure Engineer Corps is producing quality work and meeting goals."
+  access_level: 10
+  AIT: "N/A"
+- id: 26
+  name: "Section Leader"
+  active: false
+  order: 0
+  description: ""
+  access_level: 10
+  AIT: "Leadership"
+- id: 27
+  name: "Battalion S-3"
+  active: true
+  order: 47
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 28
+  name: "Testing"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 29
+  name: "Battalion S-4"
+  active: true
+  order: 46
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 30
+  name: "Battalion Sergeant"
+  active: true
+  order: 41
+  description: ""
+  access_level: 10
+  AIT: "Leadership"
+- id: 31
+  name: "S-3"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 32
+  name: "S-3 Operations"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 33
+  name: "Reservist"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 34
+  name: "Reserve Platoon Leader"
+  active: false
+  order: 0
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 35
+  name: "Recruit"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 36
+  name: "Assistant Combat Engineer"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 37
+  name: "Asst. BAR Gunner"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Automatic Rifle"
+- id: 38
+  name: "BAR Gunner"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Automatic Rifle"
+- id: 39
+  name: "Bazooka"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Combat Engineer"
+- id: 40
+  name: "Chief"
+  active: false
+  order: 0
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 41
+  name: "Chief of Adjutant Corps"
+  active: true
+  order: 99
+  description: "Responsible for the smooth running of the office."
+  access_level: 10
+  AIT: "N/A"
+- id: 42
+  name: "Chief of Medical Corps"
+  active: true
+  order: 99
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 43
+  name: "Combat Technician"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Combat Engineer"
+- id: 44
+  name: "First Sergeant"
+  active: false
+  order: 0
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 45
+  name: "Grenadier"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Grenadier"
+- id: 46
+  name: "Machine Gunner"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Machine Gun"
+- id: 47
+  name: "Journalist"
+  active: true
+  order: 83
+  description: "The publications journalist is in charge of at least once a week posting a new announcement on the main website. Whether it be an article on OCS, an official scrim, recent promotions or simply a state of the unit announcement, each journalist will come up"
+  access_level: 0
+  AIT: "N/A"
+- id: 48
+  name: "Retired"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 49
+  name: "S-3 Secretary"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 50
+  name: "Shotgunner"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 51
+  name: "Sniper"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Sniper"
+- id: 52
+  name: "Heavy Gunner"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Automatic Rifle"
+- id: 53
+  name: "Special Assignment"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 54
+  name: "Advisor"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 55
+  name: "Adjutant Officer"
+  active: false
+  order: 59
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 56
+  name: "Calendar Secretary"
+  active: false
+  order: 46
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 57
+  name: "Senior Civil Affairs Editor"
+  active: true
+  order: 89
+  description: "Responsible for editing and proof-reading works written by Publications Journalists.  Will aid the Chief of Civil Affairs in maintaining regular publications and deadlines as well as acting as a liaison to HQ.  Must show good writing and language skills."
+  access_level: 5
+  AIT: "N/A"
+- id: 58
+  name: "Steam Event Secretary"
+  active: false
+  order: 35
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 59
+  name: "Steam Roster Secretary"
+  active: false
+  order: 38
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 60
+  name: "Chief of Civil Affairs Corps"
+  active: true
+  order: 99
+  description: "The Chief will oversee all actions and submissions in this office. After submissions have been approved and anything is ready for publishing to the website, the chief will approve it and then it will be posted as soon as humanly possible."
+  access_level: 10
+  AIT: "N/A"
+- id: 61
+  name: "Graphics Specialist"
+  active: true
+  order: 70
+  description: "The graphics staff will take all requests and make adjustments to photos or graphics as needed. All graphics can be requested and one will be picked. Many graphics will be needed for handbooks and website publications. The graphics staff is also able to m"
+  access_level: 0
+  AIT: "N/A"
+- id: 62
+  name: "Level Technician"
+  active: true
+  order: 85
+  description: "Designs levels for use in game"
+  access_level: 0
+  AIT: "N/A"
+- id: 63
+  name: "Access Technician"
+  active: false
+  order: 55
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 64
+  name: "Chief Finance Officer"
+  active: true
+  order: 99
+  description: "Responsible for the smooth running of all the finance office."
+  access_level: 10
+  AIT: "N/A"
+- id: 65
+  name: "Chief of Intelligence Corps"
+  active: true
+  order: 99
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 66
+  name: "Intelligence Officer"
+  active: true
+  order: 89
+  description: "An Intel Officer is someone who will go out on a regular basis, scoping out other realism units. An IO Also makes sure the current information on a unit is  up to date. Information on any unit should not by any circumstances be outdated."
+  access_level: 0
+  AIT: "N/A"
+- id: 67
+  name: "Chief of Lighthouse Corps"
+  active: true
+  order: 99
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 68
+  name: "Senior Drill Instructor"
+  active: true
+  order: 0
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 69
+  name: "Asst. Drill Instructor"
+  active: false
+  order: 66
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 70
+  name: "Enlistment Liaison"
+  active: false
+  order: 55
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 71
+  name: "Lighthouse Secretary"
+  active: true
+  order: 90
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 72
+  name: "Recruitment Secretary"
+  active: true
+  order: 38
+  description: "Keeps the recruitment record up-to-date, posting weekend passes for recruiters, as well as awarding Combat Action Badges to those eligible."
+  access_level: 0
+  AIT: "N/A"
+- id: 73
+  name: "Postal Secretary"
+  active: true
+  order: 25
+  description: "In charge of sending emails to cadets before the training platoon starts, while it is in training, and after the training platoon graduates. Is required to be online at certain times to make sure that the emails are sent promptly and on time."
+  access_level: 0
+  AIT: "N/A"
+- id: 74
+  name: "Steam Community Secretary"
+  active: true
+  order: 31
+  description: "Creates new Steam Community Groups for each Training Platoon, schedules events and reminders for each day of Basic Training, and ensures all cadets join the group."
+  access_level: 0
+  AIT: "N/A"
+- id: 75
+  name: "Medical Technician"
+  active: true
+  order: 84
+  description: "Tends to any technical difficulties or trouble with in-game technical operations, as well proactively suggests to the company ways to keep their computers running to their full potential.\r\n"
+  access_level: 0
+  AIT: "N/A"
+- id: 76
+  name: "Clerk"
+  active: true
+  order: 45
+  description: "Organizes the content and requests in the Medical Office, creating a layout that will provide easy answers to future problems.\r\n"
+  access_level: 0
+  AIT: "N/A"
+- id: 77
+  name: "Chief of Military Police Corps"
+  active: true
+  order: 99
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 78
+  name: "Senior Military Police Officer"
+  active: true
+  order: 89
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 79
+  name: "Chief of Operations Corps"
+  active: true
+  order: 99
+  description: "Overseer of all activities in the office."
+  access_level: 10
+  AIT: "N/A"
+- id: 80
+  name: "Operations Secretary"
+  active: false
+  order: 88
+  description: "Responsible for mantaining contact with members from outside of Operations."
+  access_level: 0
+  AIT: "N/A"
+- id: 81
+  name: "Chief of Quartermaster Corps"
+  active: true
+  order: 99
+  description: "Responsible for the smooth running of all the quartermaster office."
+  access_level: 10
+  AIT: "N/A"
+- id: 82
+  name: "Quartermaster"
+  active: true
+  order: 60
+  description: "Make stamps, signatures and videos as needed by other branches of the unit."
+  access_level: 0
+  AIT: "N/A"
+- id: 83
+  name: "Quartermaster Secretary"
+  active: true
+  order: 88
+  description: "In charge of adding awards and promotions to their assigned Platoon\\'s List of Tasks, as well as updating that Platoon\\'s Tour of Duties."
+  access_level: 5
+  AIT: "N/A"
+- id: 84
+  name: "Head of Operations"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 85
+  name: "Signal Corps Officer"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 86
+  name: "Chief of Signal Corps"
+  active: true
+  order: 99
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 87
+  name: "Intelligence Secretary"
+  active: true
+  order: 55
+  description: "Someone who will take the information given to them by the Intel Officers and organize it. They will make sure to remind officers to keep info up to date. Report any changes in the information."
+  access_level: 0
+  AIT: "N/A"
+- id: 88
+  name: "SOP Planner"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 89
+  name: "Signal Office Clerk"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 90
+  name: "Chief of Infantry School"
+  active: false
+  order: 0
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 91
+  name: "Infantry School Secretary"
+  active: false
+  order: 5
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 92
+  name: "S-3 Staff"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 93
+  name: "Head of Darkest Hour Public Relations"
+  active: false
+  order: 19
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 94
+  name: "Contact Registrar"
+  active: false
+  order: 48
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 95
+  name: "Soldier Inquirer"
+  active: true
+  order: 68
+  description: "Contacts any soldier who receives a general discharge due to attendance demerits."
+  access_level: 0
+  AIT: "N/A"
+- id: 96
+  name: "Test Secretary"
+  active: false
+  order: 36
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 97
+  name: "Tester"
+  active: false
+  order: 33
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 98
+  name: "Assistant Editor"
+  active: false
+  order: 85
+  description: "Will aid the Editor in Chief of Civil Affairs Corps in editing and proof-reading works written by Publications Journalists. Must show good writing and language skills.\r\n"
+  access_level: 0
+  AIT: "N/A"
+- id: 99
+  name: "Head Test Secretary"
+  active: false
+  order: 38
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 100
+  name: "Operations Clerk"
+  active: true
+  order: 85
+  description: "In charge of organising Operations internal administration, ensuring information is organised correctly within the Office. Writing skills are a necessity, and other skills such as photoshopping and excel will also be very useful."
+  access_level: 0
+  AIT: "N/A"
+- id: 101
+  name: "Operations Planner"
+  active: false
+  order: 82
+  description: "Responsible for coming up with various scenarios, as well as summarize their scenarios in order for them to be properly tested.\n"
+  access_level: 0
+  AIT: "N/A"
+- id: 102
+  name: "Chief Clerk"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 103
+  name: "Asst. Chief of Adjutant Corps"
+  active: true
+  order: 97
+  description: "Aids the Chief in running the office."
+  access_level: 5
+  AIT: "N/A"
+- id: 104
+  name: "Senior Enlistment Liaison"
+  active: true
+  order: 59
+  description: "In charge of training and leading all Enlistment Liaisons."
+  access_level: 5
+  AIT: "N/A"
+- id: 105
+  name: "Adjutant Monitor"
+  active: true
+  order: 55
+  description: "Sends out emails to anybody in the unit who accumulates two AWOL's"
+  access_level: 0
+  AIT: "N/A"
+- id: 106
+  name: "Head Contact Registrar"
+  active: false
+  order: 74
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 107
+  name: "Head Soldier Inquirer"
+  active: false
+  order: 77
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 108
+  name: "Server Technician"
+  active: false
+  order: 60
+  description: "Keeps the 29th servers fresh with quality custom levels, content, and keeps the servers globalized with equal content."
+  access_level: 0
+  AIT: "N/A"
+- id: 109
+  name: "Code Technician"
+  active: false
+  order: 50
+  description: "Designs, writes, and releases coded content for the 29th."
+  access_level: 0
+  AIT: "N/A"
+- id: 110
+  name: "Deputy Engineer Chief"
+  active: false
+  order: 95
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 111
+  name: "3D Technician"
+  active: true
+  order: 30
+  description: "Designs models and animations for use in-game"
+  access_level: 0
+  AIT: "N/A"
+- id: 112
+  name: "Rifle School Cadre"
+  active: false
+  order: 11
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 113
+  name: "Auto Rifle School Cadre"
+  active: false
+  order: 12
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 114
+  name: "Mortar School Cadre"
+  active: false
+  order: 13
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 115
+  name: "CE School Cadre"
+  active: false
+  order: 14
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 116
+  name: "MG School Cadre"
+  active: false
+  order: 15
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 117
+  name: "Sniper School Cadre"
+  active: false
+  order: 16
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 118
+  name: "Senior Scrimmage Admin"
+  active: true
+  order: 68
+  description: "Sets the standards and oversees the training of the Scrimmage Admins.\r\n"
+  access_level: 0
+  AIT: "N/A"
+- id: 119
+  name: "Scrimmage Admin"
+  active: true
+  order: 64
+  description: "In charge of running Battalion Scrimmages in and out of the 29th. Has the permission and the Admin to start and lead Pub/29th only Scrims.\r\n"
+  access_level: 0
+  AIT: "N/A"
+- id: 120
+  name: "Darkest Hour Public Relations"
+  active: false
+  order: 18
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 121
+  name: "Attendance Adjutant"
+  active: false
+  order: 57
+  description: "Responsible for monitoring and reporting monthly attendance."
+  access_level: 0
+  AIT: "N/A"
+- id: 122
+  name: "Armored School Cadre"
+  active: false
+  order: 17
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 123
+  name: "Newsletter Contributor"
+  active: false
+  order: 54
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 124
+  name: "Newsletter Editor in Chief"
+  active: false
+  order: 58
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 125
+  name: "Asst. Chief of Engineer Corps"
+  active: true
+  order: 97
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 126
+  name: "Senior Attendance Adjutant"
+  active: true
+  order: 89
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 127
+  name: "Submachine Gun School Cadre"
+  active: false
+  order: 18
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 128
+  name: "Field Reporter"
+  active: false
+  order: 46
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 129
+  name: "Asst. Chief of Medical Corps"
+  active: true
+  order: 97
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 130
+  name: "Senior Medical Technician"
+  active: true
+  order: 88
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 131
+  name: "Assistant Chief of Lighthouse"
+  active: true
+  order: 97
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 132
+  name: "Military Police Officer"
+  active: true
+  order: 87
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 133
+  name: "Server Admin"
+  active: true
+  order: 55
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 134
+  name: "Civil Affairs Photographer"
+  active: true
+  order: 21
+  description: "Responsible for taking screenshots and videos of 29th events for publication."
+  access_level: 0
+  AIT: "N/A"
+- id: 135
+  name: "Senior Clerk"
+  active: true
+  order: 77
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 136
+  name: "Battalion Liason"
+  active: true
+  order: 93
+  description: "Responsible for reporting activities of the office to the Battalion."
+  access_level: 0
+  AIT: "N/A"
+- id: 137
+  name: "Project Admin"
+  active: true
+  order: 53
+  description: "Responsible for coming up, developing and running different events and scrimmage scenarios for the 29th.\r\n"
+  access_level: 0
+  AIT: "N/A"
+- id: 138
+  name: "Project Assistant"
+  active: true
+  order: 57
+  description: "Responsible for assisting the Project Admin in his projects.\r\n"
+  access_level: 0
+  AIT: "N/A"
+- id: 139
+  name: "Senior Recruitment Officer"
+  active: true
+  order: 35
+  description: "Responsible for improving 29th recruiting operations through events and incentives as well as assisting in any problems with recruiting on a soldier to soldier basis. Is also a resource for cadets in the 29th for any problems they have that go beyond the "
+  access_level: 5
+  AIT: "N/A"
+- id: 140
+  name: "Wiki Editor"
+  active: true
+  order: 18
+  description: "Responsible for keeping the 29th Wiki up to date and editing the Wiki when information becomes obsolete."
+  access_level: 0
+  AIT: "N/A"
+- id: 141
+  name: "Medic"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 142
+  name: "Finance Officer"
+  active: true
+  order: 88
+  description: "Responsible for the donation process, producing the topics in the 'Promotions and Awards' board."
+  access_level: 0
+  AIT: "N/A"
+- id: 143
+  name: "Radio Operator"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 144
+  name: "Fireteam Leader"
+  active: true
+  order: 7
+  description: ""
+  access_level: 0
+  AIT: "Leadership"
+- id: 145
+  name: "Assistant Chief Fundraising Officer"
+  active: true
+  order: 85
+  description: "Responsible for acknowledging posters and articles provided by the Fundraising Officers, and will be approved by the Chief."
+  access_level: 0
+  AIT: "N/A"
+- id: 146
+  name: "Fundraising Officer"
+  active: true
+  order: 81
+  description: "Responsible for the formulation of posters, articles and videos to increase donations in the 29th Infantry Division."
+  access_level: 0
+  AIT: "N/A"
+- id: 147
+  name: "Senior Drill Instructor - RS"
+  active: true
+  order: 89
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 148
+  name: "Senior Drill Instructor - DH"
+  active: false
+  order: 88
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 149
+  name: "Drill Instructor - DH"
+  active: false
+  order: 78
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 150
+  name: "Drill Instructor - RS2"
+  active: true
+  order: 76
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 151
+  name: "Drill Instructor - RS"
+  active: true
+  order: 79
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 152
+  name: "Drill Instructor - A3"
+  active: true
+  order: 77
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 153
+  name: "Enlistment Enforcement Officer"
+  active: true
+  order: 48
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 154
+  name: "Signal Corps Community Contact"
+  active: true
+  order: 65
+  description: "Responsible for obtaining, maintaining, and promoting cohesion between units outside the 29th as well as collecting data for that unit vital to maintain communication."
+  access_level: 0
+  AIT: "N/A"
+- id: 155
+  name: "Senior Community Contact - DH"
+  active: false
+  order: 80
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 156
+  name: "Senior Community Contact - RS"
+  active: true
+  order: 79
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 157
+  name: "Senior Community Contact - A3"
+  active: true
+  order: 78
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 158
+  name: "Realism Website Designer/Maintainer"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 159
+  name: "Signal Corps Clerk"
+  active: true
+  order: 87
+  description: "Signal Corp Clerks have the task of creating Signal Corps publications, data lists, meeting notes, inter-unit messages, etc\n"
+  access_level: 5
+  AIT: "N/A"
+- id: 160
+  name: "Fundraising Editor"
+  active: true
+  order: 43
+  description: "Provides grammatical and punctuation checks for posters and articles made by the Fundraising Officers."
+  access_level: 0
+  AIT: "N/A"
+- id: 161
+  name: "Finance Clerk"
+  active: true
+  order: 90
+  description: "Provides weapon passes to donators."
+  access_level: 0
+  AIT: "N/A"
+- id: 162
+  name: "Senior Drill Instructor - A3"
+  active: true
+  order: 87
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 163
+  name: "Signal Corps Lead Clerk"
+  active: true
+  order: 89
+  description: "Signal Corps Lead Clerk has the task of creating Signal Office publications, data lists, meeting notes, inter-unit messages, etc. as well as assigning tasks to other clerks in Signal Corps.   -Cannot Apply For-"
+  access_level: 0
+  AIT: "N/A"
+- id: 164
+  name: "Assistant Chief Finance Officer"
+  active: true
+  order: 97
+  description: "Responsible for acknowledging donations, covering all received donations and outgoing costs over a period of 2 weeks."
+  access_level: 10
+  AIT: "N/A"
+- id: 166
+  name: "Video Publications Specialist"
+  active: false
+  order: 76
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 167
+  name: "Assistant Video Publications Specialist"
+  active: false
+  order: 74
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 168
+  name: "Chief Reservist"
+  active: true
+  order: 99
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 169
+  name: "Support Staff"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 170
+  name: "Assistant Chief Finance Graphics Editor"
+  active: true
+  order: 45
+  description: "Responsible for supervising the graphics staff and sending up their work to the Chief."
+  access_level: 0
+  AIT: "N/A"
+- id: 171
+  name: "Finance Graphics Editor"
+  active: true
+  order: 22
+  description: "Provides the set of skills needed to make Fundraising posters and articles look nice, also creates graphics documents."
+  access_level: 0
+  AIT: "N/A"
+- id: 172
+  name: "Senior Medical Technician - DH"
+  active: false
+  order: 69
+  description: "Lead Technician in charge of all in-game issues within Darkest Hour."
+  access_level: 0
+  AIT: "N/A"
+- id: 173
+  name: "Senior Medical Technician - RS"
+  active: false
+  order: 68
+  description: "Lead Technician in charge of all issues in-game with Rising Storm."
+  access_level: 0
+  AIT: "N/A"
+- id: 174
+  name: "Senior Medical Technician - A3"
+  active: false
+  order: 67
+  description: "Lead Technician in charge of all in-game issues with Arma 3"
+  access_level: 0
+  AIT: "N/A"
+- id: 175
+  name: "Medical Technician - DH"
+  active: false
+  order: 64
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 176
+  name: "Medical Technician - RS"
+  active: true
+  order: 65
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 177
+  name: "Medical Technician - A3"
+  active: true
+  order: 63
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 178
+  name: "Mission Technician - A3"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 179
+  name: "Pilot"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Pilot"
+- id: 180
+  name: "AWOL Adjutant"
+  active: true
+  order: 50
+  description: "Responsible for posting demerits and AWOL's maintaining records pertaining to demerits"
+  access_level: 0
+  AIT: "N/A"
+- id: 181
+  name: "Lighthouse Support Staff"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 182
+  name: "Adjutant Clerk"
+  active: true
+  order: 42
+  description: "Responsible for keeping up to date the Adjutant Monitor and the Soldier Inquirer tasks as well as administrating the surveys to certain soldiers."
+  access_level: 0
+  AIT: "N/A"
+- id: 183
+  name: "Asst. Drill Instructor - A3"
+  active: true
+  order: 67
+  description: "Serves as the Drill Instructor's right hand man in Basic Combat Training, helping him teach the cadets, posting the drill report at the end of the night (attendance, etc.). If the Asst. DI does a good enough job he can be certified as a Drill Instructor."
+  access_level: 0
+  AIT: "N/A"
+- id: 184
+  name: "Asst. Drill Instructor - DH"
+  active: false
+  order: 68
+  description: "Serves as the Drill Instructor's right hand man in Basic Combat Training, helping him teach the cadets, posting the drill report at the end of the night (attendance, etc.). If the Asst. DI does a good enough job he can be certified as a Drill Instructor."
+  access_level: 0
+  AIT: "N/A"
+- id: 185
+  name: "Asst. Drill Instructor - RS"
+  active: true
+  order: 69
+  description: "Serves as the Drill Instructor's right hand man in Basic Combat Training, helping him teach the cadets, posting the drill report at the end of the night (attendance, etc.). If the Asst. DI does a good enough job he can be certified as a Drill Instructor."
+  access_level: 0
+  AIT: "N/A"
+- id: 186
+  name: "Civil Affairs Editor"
+  active: true
+  order: 83
+  description: "Will aid the Editor in Chief of Civil Affairs Corps in editing and proof-reading works written by Publicists and video works created by the Video Staff of Adjutant Corps for Civil Affairs. Must show good writing and language skills."
+  access_level: 0
+  AIT: "N/A"
+- id: 187
+  name: "Enlistment Liaison - DH"
+  active: false
+  order: 56
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 188
+  name: "Enlistment Liaison - A3"
+  active: true
+  order: 55
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 189
+  name: "Enlistment Liaison - RS"
+  active: false
+  order: 57
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 190
+  name: "Lead Journalist"
+  active: true
+  order: 84
+  description: "In charge of written projects for Civil Affairs. Works directly with Publicists to create and finalize projects for the 29th."
+  access_level: 5
+  AIT: "N/A"
+- id: 192
+  name: "Realism Website Designer/Maintainer - Lead"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 193
+  name: "Senior Postal Secretary"
+  active: true
+  order: 27
+  description: "Is in charge off all Postal Secretaries in LH, reports directly to Chief of LH as part of the senior staff."
+  access_level: 5
+  AIT: "N/A"
+- id: 194
+  name: "Chief of S-3"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 195
+  name: "Expert Infantry School Cadre"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 196
+  name: "Temporary"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 197
+  name: "Statistical Accountant"
+  active: true
+  order: 92
+  description: "Records donations of 29th members in an Excel sheet. "
+  access_level: 0
+  AIT: "N/A"
+- id: 198
+  name: "Battalion S-1"
+  active: true
+  order: 98
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 199
+  name: "Battalion S-2"
+  active: true
+  order: 48
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 202
+  name: "ELOA Adjutant"
+  active: true
+  order: 15
+  description: "Responsible for creating the new entries in the ELOA system."
+  access_level: 0
+  AIT: "N/A"
+- id: 203
+  name: "Finance Secretary"
+  active: true
+  order: 93
+  description: "Responsible for sending out a detailed PM to all members of a newly graduated Training Platoon explaining to them what the Finance Office is and what it's used for."
+  access_level: 5
+  AIT: "N/A"
+- id: 204
+  name: "Assistant Chief Quartermaster"
+  active: false
+  order: 80
+  description: "Responsible for quality control over any graphics work needed and aids the chief in the smooth running of the office."
+  access_level: 5
+  AIT: "N/A"
+- id: 205
+  name: "Chief of Ordnance Corps"
+  active: true
+  order: 99
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 206
+  name: "Ordnance Clerk"
+  active: true
+  order: 50
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 207
+  name: "SLT Candidate"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 208
+  name: "Senior Video Editor"
+  active: true
+  order: 85
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 209
+  name: "Video Editor"
+  active: true
+  order: 82
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 210
+  name: "Senior Quartermaster"
+  active: true
+  order: 65
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 212
+  name: "Camera Crew - RS"
+  active: false
+  order: 53
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 213
+  name: "Camera Crew - DH"
+  active: false
+  order: 54
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 214
+  name: "Camera Crew - A3"
+  active: true
+  order: 52
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 215
+  name: "Battalion Clerk"
+  active: true
+  order: 22
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 216
+  name: "Lead Publicist"
+  active: true
+  order: 85
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 217
+  name: "Publicist"
+  active: true
+  order: 82
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 218
+  name: "Field Reporter - DH"
+  active: false
+  order: 45
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 219
+  name: "Field Reporter - RS"
+  active: true
+  order: 46
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 220
+  name: "Field Reporter - A3"
+  active: true
+  order: 44
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 222
+  name: "Community Manager"
+  active: false
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 223
+  name: "AWOL Secretary"
+  active: true
+  order: 53
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 224
+  name: "Senior Wiki Editor"
+  active: true
+  order: 20
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 225
+  name: "Senior Level Technician"
+  active: true
+  order: 86
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 226
+  name: "Logistics Technician"
+  active: true
+  order: 79
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 227
+  name: "Tactical Technician"
+  active: true
+  order: 72
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 228
+  name: "Records Clerk"
+  active: true
+  order: 69
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 229
+  name: "Asst. Chief of Civil Affairs Office"
+  active: true
+  order: 95
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 230
+  name: "Operations Clerk"
+  active: false
+  order: 69
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 231
+  name: "Operations Record Keeper"
+  active: true
+  order: 69
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 232
+  name: "Tank Commander"
+  active: true
+  order: 50
+  description: ""
+  access_level: 0
+  AIT: "Armor"
+- id: 233
+  name: "First Class Tanker"
+  active: false
+  order: 40
+  description: ""
+  access_level: 0
+  AIT: "Armor"
+- id: 234
+  name: "Second Class Tanker"
+  active: false
+  order: 30
+  description: ""
+  access_level: 0
+  AIT: "Armor"
+- id: 235
+  name: "Mortar Operator"
+  active: true
+  order: 1
+  description: ""
+  access_level: 0
+  AIT: "Mortar"
+- id: 236
+  name: "Mortar Observer"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Mortar"
+- id: 237
+  name: "MP Secretary"
+  active: true
+  order: 46
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 238
+  name: "Assistant Chief of Military Police Corps"
+  active: true
+  order: 98
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 239
+  name: "Senior Tactical Technician"
+  active: true
+  order: 74
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 240
+  name: "Print Journalist"
+  active: true
+  order: 82
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 241
+  name: "Interview Journalist"
+  active: true
+  order: 81
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 242
+  name: "Senior Logistical Technician"
+  active: true
+  order: 75
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 243
+  name: "Signal Corps Assistant Liaison"
+  active: true
+  order: 34
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 244
+  name: "Senior AWOL Secretary"
+  active: true
+  order: 54
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 245
+  name: "Senior AWOL Adjutant"
+  active: true
+  order: 51
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 246
+  name: "Senior Adjutant Clerk"
+  active: true
+  order: 43
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 248
+  name: "Senior Field Reporter"
+  active: true
+  order: 47
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 249
+  name: "Senior Platoon Sniper"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "Sniper"
+- id: 250
+  name: "Senior ELOA Adjutant"
+  active: true
+  order: 16
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 251
+  name: "Adjutant Secretary"
+  active: true
+  order: 80
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 252
+  name: "Chief Server Administrator - RS"
+  active: true
+  order: 89
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 253
+  name: "Chief Server Administrator - DH"
+  active: false
+  order: 69
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 254
+  name: "Chief Server Administrator - A3"
+  active: true
+  order: 49
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 255
+  name: "Senior Code Technician - RS"
+  active: true
+  order: 87
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 256
+  name: "Code Technician - RS"
+  active: true
+  order: 84
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 257
+  name: "Level Technician - RS"
+  active: true
+  order: 77
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 258
+  name: "Server Level Technician - RS"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 259
+  name: "Senior Code Technician - DH"
+  active: false
+  order: 66
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 260
+  name: "Code Technician - DH"
+  active: true
+  order: 63
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 261
+  name: "Senior Level Technician - DH"
+  active: true
+  order: 60
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 262
+  name: "Level Technician - DH"
+  active: true
+  order: 58
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 263
+  name: "Senior Technician - A3"
+  active: true
+  order: 46
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 264
+  name: "Technician - A3"
+  active: true
+  order: 43
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 265
+  name: "Senior Web Technician"
+  active: true
+  order: 83
+  description: null
+  access_level: 5
+  AIT: "N/A"
+- id: 266
+  name: "Web Technician"
+  active: true
+  order: 82
+  description: null
+  access_level: 0
+  AIT: "N/A"
+- id: 267
+  name: "Senior Level Technician - RS"
+  active: true
+  order: 79
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 268
+  name: "Chief Web Technician"
+  active: true
+  order: 38
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 269
+  name: "Crewman First Class"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 270
+  name: "Crewman Second Class"
+  active: true
+  order: 0
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 271
+  name: "Staff Clerk"
+  active: true
+  order: 30
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 272
+  name: "Code Technician - A3"
+  active: true
+  order: 36
+  description: null
+  access_level: 0
+  AIT: "N/A"
+- id: 273
+  name: "Senior Drill Instructor - RS2"
+  active: true
+  order: 86
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 274
+  name: "Senior Drill Instructor - SQ"
+  active: true
+  order: 85
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 275
+  name: "Drill Instructor - SQ"
+  active: true
+  order: 75
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 276
+  name: "Asst. Drill Instructor - RS2"
+  active: true
+  order: 66
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 277
+  name: "Asst. Drill Instructor - SQ"
+  active: true
+  order: 65
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 278
+  name: "Enlistment Liaison - RS2"
+  active: true
+  order: 54
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 279
+  name: "Enlistment Liaison - SQ"
+  active: true
+  order: 53
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 280
+  name: "Field Reporter - RS2"
+  active: true
+  order: 43
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 281
+  name: "Field Reporter - SQ"
+  active: true
+  order: 42
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 282
+  name: "Medical Technician - RS2"
+  active: true
+  order: 62
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 283
+  name: "Medical Technician - SQ"
+  active: true
+  order: 61
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 284
+  name: "Medical Clerk"
+  active: true
+  order: 90
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 285
+  name: "Code Technician - RS2"
+  active: true
+  order: 34
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 286
+  name: "Code Technician - SQ"
+  active: true
+  order: 32
+  description: null
+  access_level: 0
+  AIT: "N/A"
+- id: 287
+  name: "Senior Level Technician - RS2"
+  active: true
+  order: 28
+  description: null
+  access_level: 0
+  AIT: "N/A"
+- id: 288
+  name: "Senior Level Technician - SQ"
+  active: true
+  order: 26
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 289
+  name: "Level Technician - RS2"
+  active: true
+  order: 27
+  description: null
+  access_level: 0
+  AIT: "N/A"
+- id: 290
+  name: "Level Technician - SQ"
+  active: true
+  order: 25
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 291
+  name: "Chief Server Administrator - RS2"
+  active: true
+  order: 39
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 292
+  name: "Chief Server Administrator - SQ"
+  active: true
+  order: 29
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 293
+  name: "Camera Crew - RS2"
+  active: true
+  order: 51
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 294
+  name: "Camera Crew - SQ"
+  active: true
+  order: 50
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 295
+  name: "Music Composer"
+  active: true
+  order: 40
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 296
+  name: "Senior Adjutant Monitor"
+  active: true
+  order: 56
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 297
+  name: "Senior Community Contact - RS2"
+  active: true
+  order: 77
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 298
+  name: "Senior Community Contact - SQ"
+  active: true
+  order: 76
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 299
+  name: "Engineer Office Clerk"
+  active: true
+  order: 92
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 300
+  name: "Senior Enlistment Clerk"
+  active: true
+  order: 52
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 301
+  name: "Enlistment Clerk"
+  active: true
+  order: 51
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 302
+  name: "Supervisor of Enlistment Corps"
+  active: true
+  order: 61
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 303
+  name: "Enlistment Clerk - A3"
+  active: true
+  order: 51
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 304
+  name: "Enlistment Clerk - RS2"
+  active: true
+  order: 50
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 305
+  name: "Enlistment Clerk - SQ"
+  active: true
+  order: 49
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 306
+  name: "Chief of Public Affairs Corps"
+  active: false
+  order: 99
+  description: "Responsible for hiring of all positions within the office and management of all operations within the office."
+  access_level: 10
+  AIT: "N/A"
+- id: 307
+  name: "Public Relations Officer"
+  active: true
+  order: 79
+  description: "Responsible for casting and commentary using the 29th\u2019s streaming platforms including Twitch and Youtube."
+  access_level: 0
+  AIT: "N/A"
+- id: 308
+  name: "Combat Cameraman"
+  active: false
+  order: 59
+  description: "Responsible for all camera work and streaming"
+  access_level: 0
+  AIT: "N/A"
+- id: 309
+  name: "Executive Producer"
+  active: true
+  order: 86
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 310
+  name: "Assistant Chief of Quartermaster Corps"
+  active: true
+  order: 98
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 311
+  name: "Senior Camera Crew"
+  active: true
+  order: 57
+  description: null
+  access_level: 5
+  AIT: "N/A"
+- id: 312
+  name: "Regiment SNCO"
+  active: true
+  order: 41
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 313
+  name: "Regiment Clerk"
+  active: true
+  order: 22
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 314
+  name: "Regiment Commander"
+  active: true
+  order: 100
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 315
+  name: "Ordnance Instructor"
+  active: true
+  order: 55
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 316
+  name: "Ordnance Senior Instructor"
+  active: true
+  order: 85
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 317
+  name: "Assistant Chief of Ordnance Corps"
+  active: true
+  order: 95
+  description: ""
+  access_level: 10
+  AIT: "N/A"
+- id: 318
+  name: "Senior Finance Officer"
+  active: true
+  order: 89
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 319
+  name: "Assistant Chief of Civil Affairs"
+  active: true
+  order: 95
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 320
+  name: "Senior War Correspondent"
+  active: true
+  order: 60
+  description: ""
+  access_level: 5
+  AIT: "N/A"
+- id: 321
+  name: "War Correspondent - A3"
+  active: true
+  order: 60
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 322
+  name: "Civil Affairs Monitor"
+  active: true
+  order: 60
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 323
+  name: "War Correspondent - RS2"
+  active: true
+  order: 60
+  description: ""
+  access_level: 0
+  AIT: "N/A"
+- id: 324
+  name: "War Correspondent - SQ"
+  active: true
+  order: 60
+  description: ""
+  access_level: 0
+  AIT: "N/A"

--- a/db/seeds/data/ranks.yml
+++ b/db/seeds/data/ranks.yml
@@ -1,0 +1,175 @@
+- id: 1
+  name: "Recruit"
+  abbr: "Rec."
+  grade: ""
+  filename: "pvt.png"
+  order: 1
+  description: "Recruits are uninitiated members of the unit. They are awaiting or completing their Basic Combat Training to earn the privileges of a full member of the unit. Upon completion of BCT, they are promoted to Private."
+- id: 2
+  name: "Private"
+  abbr: "Pvt."
+  grade: "E-1"
+  filename: "pvt.png"
+  order: 2
+  description: "Once cadets graduate basic combat training, they receive the 29th ID shoulder patch and serve to carry out orders to the best of their ability."
+- id: 3
+  name: "Private, First Class"
+  abbr: "PFC"
+  grade: "E-2"
+  filename: "pfc.png"
+  order: 3
+  description: "This rank is awarded to Privates who have become valuable to the Squad Leaders. They assist in drills, showing other Privates the ropes, and are next in line for leadership positions."
+- id: 4
+  name: "Technician, 5th Grade"
+  abbr: "T/5"
+  grade: "E-3"
+  filename: "t5.png"
+  order: 4
+  description: "Equivelant to Corporal, a T/5 has been qualified to specialize in a certain area, such as clerical or office work, or combat engineer weapons."
+- id: 5
+  name: "Corporal"
+  abbr: "Cpl."
+  grade: "E-3"
+  filename: "cpl.png"
+  order: 5
+  description: "The entry-level NCO rank, a corporal is a PFC who has proven himself in Leadership training and is capable of leading other soldiers. A Corporal is usually an Assistant Squad Leader, but can also lead squads if necessary. Usually does not discipline the men as much as a higher NCO, but acts as a team leader."
+- id: 6
+  name: "Technician, 4th Grade"
+  abbr: "T/4"
+  grade: "E-4"
+  filename: "t4.png"
+  order: 6
+  description: "Equivelant to Sergeant, this enlisted soldier is a proven specialist at a particular area, and often is in charge of training other specialists under him."
+- id: 7
+  name: "Sergeant"
+  abbr: "Sgt."
+  grade: "E-4"
+  filename: "sgt.png"
+  order: 7
+  description: "A Sergeant is a proven Corporal who is placed in charge of a squad and is in charge of his squad's discipline, appearance, and organization. Sergeants call practices and drills for their squad when necessary. In some cases, a Sergeant may be a part of a platoon headquarters."
+- id: 8
+  name: "Technician, 3rd Grade"
+  abbr: "T/3"
+  grade: "E-5"
+  filename: "t3.png"
+  order: 8
+  description: "Equivelant to Staff Sergeant, this enlisted soldier specializes in a certain area, such as head of a particular office in Headquarters Support Staff, Clerical Work, or even a highly proven Combat Engineer."
+- id: 9
+  name: "Staff Sergeant"
+  abbr: "SSgt."
+  grade: "E-5"
+  filename: "ssgt.png"
+  order: 9
+  description: "A Staff Sergeant has many of the same responsibilities as a Sergeant, but has even more exceptional leadership skills which come natural to him. Often has sergeants working under him and can lead a platoon or act as an advisor to the platoon leader."
+- id: 10
+  name: "Technical Sergeant"
+  abbr: "TSgt."
+  grade: "E-6"
+  filename: "tsgt.png"
+  order: 10
+  description: "A Technical Sergeant is a seasoned leader who typically serves as platoon sergeant in a highly distinguished capacity. In some cases, a Technical Sergeant can hold a Company HQ position. The key advisor to the platoon leader."
+- id: 11
+  name: "First Sergeant"
+  abbr: "FSgt."
+  grade: "E-8"
+  filename: "fsgt.png"
+  order: 12
+  description: "A key advisor to the Commander, the First Sergeant is often the most respected member of the company, and known as the \"Company Boss.\" Helps run the company by dispatching leadership training and has much experience under his belt."
+- id: 12
+  name: "Master Sergeant"
+  abbr: "MSgt."
+  grade: "E-8"
+  filename: "msgt.png"
+  order: 11
+  description: "A key advisor to the Commander, the Master Sergeant is the second highest ranking NCO rank possible in a company. Typically a Master Sergeant fulfills the same duties as a First Sergeant or acts as an assisting member of leadership to the First Sergeant. In the absence of a First Sergeant, the Master Sergeant is the Senior NCO of a company."
+- id: 13
+  name: "Warrant Officer 1"
+  abbr: "WO1"
+  grade: "W-1"
+  filename: "wo1.png"
+  order: 15
+  description: "Warrant Officer 1 fills the role of a Platoon Leader by someone who is typically in lieu of a 2nd Lieutenant."
+- id: 14
+  name: "Chief Warrant Officer 2"
+  abbr: "CW2"
+  grade: "W-2"
+  filename: "cw2.png"
+  order: 16
+  description: "Chief Warrant Officer 2 fills the role of an Company Executive Officer by someone who is typically in lieu of a 1st Lieutenant."
+- id: 15
+  name: "Chief Warrant Officer 3"
+  abbr: "CW3"
+  grade: "W-3"
+  filename: "cw3.png"
+  order: 17
+  description: "Chief Warrant Officer 3 fills the role of a Company Commander by someone who is typically in lieu of a Captain."
+- id: 16
+  name: "Chief Warrant Officer 4"
+  abbr: "CW4"
+  grade: "W-4"
+  filename: "cw4.png"
+  order: 18
+  description: "Chief Warrant Officer 4 fills the role of a Battalion Executive Officer by someone who is typically in lieu of a Major."
+- id: 17
+  name: "Chief Warrant Officer 5"
+  abbr: "CW5"
+  grade: "W-5"
+  filename: "cw5.png"
+  order: 19
+  description: "Chief Warrant Officer 5 fills the role of a Battalion Commander by someone who is typically in lieu of a Lieutenant Colonel."
+- id: 18
+  name: "Second Lieutenant"
+  abbr: "2Lt."
+  grade: "O-1"
+  filename: "2lt.png"
+  order: 20
+  description: "The entry-level Officer rank, who typically leads a platoon under the Company HQ's command.\r\n"
+- id: 19
+  name: "First Lieutenant"
+  abbr: "1Lt."
+  grade: "O-2"
+  filename: "1lt.png"
+  order: 21
+  description: "Usually the Executive Officer (XO) of the company, the First Lieutenant is second in command and executes orders from the Captain, but can be the Commanding Officer in absence of a Captain, or can lead a platoon if necessary.\r\n"
+- id: 20
+  name: "Captain"
+  abbr: "Cpt."
+  grade: "O-3"
+  filename: "cpt.png"
+  order: 22
+  description: "The Captain commands a Company, and is also referred to as the Company's Commanding Officer (CO). He does not lead a platoon, but is the highest rank in the Company HQ.\r\n"
+- id: 21
+  name: "Major"
+  abbr: "Maj."
+  grade: "O-4"
+  filename: "maj.png"
+  order: 23
+  description: "The Major is usually the Executive Officer of the Battalion, but can be the Commanding Officer in absence of a Lieutenant Colonel.\r\n"
+- id: 22
+  name: "Lieutenant Colonel"
+  abbr: "Lt. Col."
+  grade: "O-5"
+  filename: "ltcol.png"
+  order: 24
+  description: "The Lieutenant Colonel commands the entire Battalion, and is also referred to as the Commanding Officer, or CO, and does not lead a company, but is the highest rank in the Battalion HQ."
+- id: 24
+  name: "Sergeant Major"
+  abbr: "Sgt. Maj"
+  grade: "E-9"
+  filename: "sgtmaj.png"
+  order: 13
+  description: "A Sergeant Major is typically the Senior NCO for an entire Battalion. This rank is the second highest in the unit and is a mark of a distinguished and knowledgeable leader. The Sergeant Major is the go-to advisor for the battalion leader."
+- id: 25
+  name: "Command Sergeant Major"
+  abbr: "CSM"
+  grade: "E-9"
+  filename: "csm.png"
+  order: 14
+  description: "The Command Sergeant Major serves as the advisor to the regiment commander and is the highest NCO rank in the regiment. "
+- id: 26
+  name: "Colonel"
+  abbr: "Col."
+  grade: "O-6"
+  filename: "col.png"
+  order: 25
+  description: "The Colonel commands the entire Regiment, and is also referred to as the Commanding Officer, or CO."

--- a/db/seeds/data/servers.yml
+++ b/db/seeds/data/servers.yml
@@ -1,0 +1,175 @@
+- id: 1
+  name: "Battalion Server"
+  abbr: "bn"
+  address: "127.0.0.1"
+  port: 27001
+  game: "DH"
+  active: false
+- id: 2
+  name: "Euro Server"
+  abbr: "eu"
+  address: "127.0.0.1"
+  port: 27002
+  game: "DH"
+  active: false
+- id: 3
+  name: "Company Server"
+  abbr: "co"
+  address: "127.0.0.1"
+  port: 27003
+  game: "DH"
+  active: false
+- id: 4
+  name: "Platoon Server"
+  abbr: "plt"
+  address: "127.0.0.1"
+  port: 27004
+  game: "DH"
+  active: false
+- id: 5
+  name: "Squad Server"
+  abbr: "sqd"
+  address: "127.0.0.1"
+  port: 27005
+  game: "DH"
+  active: false
+- id: 6
+  name: "BCT Server"
+  abbr: "bct"
+  address: "127.0.0.1"
+  port: 27006
+  game: "DH"
+  active: false
+- id: 7
+  name: "Battalion Server"
+  abbr: "bn"
+  address: "127.0.0.1"
+  port: 27007
+  game: "RS"
+  active: false
+- id: 8
+  name: "Platoon Server"
+  abbr: "plt"
+  address: "127.0.0.1"
+  port: 27008
+  game: "RS"
+  active: false
+- id: 9
+  name: "Squad Server"
+  abbr: "sqd"
+  address: "127.0.0.1"
+  port: 27009
+  game: "RS"
+  active: false
+- id: 10
+  name: "Battalion Server"
+  abbr: "bn"
+  address: "127.0.0.1"
+  port: 27010
+  game: "Arma 3"
+  active: true
+- id: 11
+  name: "Company Server"
+  abbr: "co"
+  address: "127.0.0.1"
+  port: 27011
+  game: "Arma 3"
+  active: true
+- id: 12
+  name: "Platoon Server"
+  abbr: "plt"
+  address: "127.0.0.1"
+  port: 27012
+  game: "Arma 3"
+  active: true
+- id: 13
+  name: "Squad Server"
+  abbr: "sqd"
+  address: "127.0.0.1"
+  port: 27013
+  game: "Arma 3"
+  active: false
+- id: 14
+  name: "Company Server"
+  abbr: "co"
+  address: "127.0.0.1"
+  port: 27014
+  game: "RS"
+  active: false
+- id: 15
+  name: "Company Server"
+  abbr: "co"
+  address: "127.0.0.1"
+  port: 27015
+  game: "RS2"
+  active: true
+- id: 16
+  name: "Company Server"
+  abbr: "co"
+  address: "127.0.0.1"
+  port: 27016
+  game: "Squad"
+  active: true
+- id: 17
+  name: "Platoon Server"
+  abbr: "plt"
+  address: "127.0.0.1"
+  port: 27017
+  game: "RS2"
+  active: true
+- id: 18
+  name: "Platoon Server"
+  abbr: "plt"
+  address: "127.0.0.1"
+  port: 27018
+  game: "Squad"
+  active: true
+- id: 19
+  name: "Public Server"
+  abbr: "pub"
+  address: "127.0.0.1"
+  port: 27019
+  game: "Squad"
+  active: false
+- id: 20
+  name: "Euro Server"
+  abbr: "eu"
+  address: "127.0.0.1"
+  port: 27020
+  game: "Squad"
+  active: false
+- id: 21
+  name: "Euro Server"
+  abbr: "eu"
+  address: "127.0.0.1"
+  port: 27021
+  game: "RS2"
+  active: true
+- id: 22
+  name: "Public Server 1"
+  abbr: "pub"
+  address: "127.0.0.1"
+  port: 27022
+  game: "RS2"
+  active: true
+- id: 23
+  name: "Public Server 2"
+  abbr: "pub"
+  address: "127.0.0.1"
+  port: 27023
+  game: "RS2"
+  active: true
+- id: 24
+  name: "Squad Server"
+  abbr: "sq"
+  address: "127.0.0.1"
+  port: 27024
+  game: "RS2"
+  active: true
+- id: 25
+  name: "Squad Server"
+  abbr: "sq"
+  address: "127.0.0.1"
+  port: 27025
+  game: "Squad"
+  active: true


### PR DESCRIPTION
I've been wanting to set this up for ages - representative sample data (aka synthetic data that resembles production) as part of the development setup, so you can get personnel running locally without a copy of the production database. But it's pretty hard to get something that resembles production.

So I had fable analyse the production data and put a data profile together, then write a script to generate data that resembles it. And it looks amazing!

To run it, assuming you have a fresh mysql 8 database and `config/database.yml` is pointing to it, just run:

```sh
bin/rails db:prepare db:seed
```

If that balks for some reason you can also just use:

```sh
bin/rails db:reset
```