### PR TITLE
Use safe accessor on forum roles pages

### DIFF
--- a/app/manage/special_forum_roles.rb
+++ b/app/manage/special_forum_roles.rb
@@ -15,7 +15,7 @@ ActiveAdmin.register SpecialForumRole do
     selectable_column
     column :special_attribute
     column :role_id do |record|
-      @roles[record.forum_id.to_sym][record.role_id]
+      @roles.dig(record.forum_id.to_sym, record.role_id)
     end
     column :forum_id
     actions

--- a/app/manage/unit_forum_roles.rb
+++ b/app/manage/unit_forum_roles.rb
@@ -17,7 +17,7 @@ ActiveAdmin.register UnitForumRole do
     column :unit
     column :access_level
     column :role_id do |record|
-      @roles[record.forum_id.to_sym][record.role_id]
+      @roles.dig(record.forum_id.to_sym, record.role_id)
     end
     column :forum_id
     actions

--- a/test/manage/manage_smoke_test.rb
+++ b/test/manage/manage_smoke_test.rb
@@ -69,7 +69,9 @@ module Manage
       create(:restricted_name, name: "Reservedname") # fixed name so Faker can't collide
       create(:server)
       create(:special_forum_role)
+      create(:special_forum_role, forum_id: :vanilla)
       create(:unit_forum_role, unit: squad)
+      create(:unit_forum_role, forum_id: :vanilla, unit: squad)
       create(:user_award, user: member)
 
       tp = create(:unit, classification: :training,


### PR DESCRIPTION
This was raising a `NoMethodError: undefined method '[]' for nil` error causing `/manage/special_forum_roles` and `/manage/unit_forum_roles` to fail. Likely because we removed the vanilla integration in November but still have some vanilla forum role records in the database.