### PR TITLE
Fix missing awards discharge preload

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,7 +24,7 @@ class User < ApplicationRecord
   has_many :non_honorable_discharges, -> { non_honorable },
     class_name: "Discharge", foreign_key: "member_id"
   has_one :latest_non_honorable_discharge, -> {
-    non_honorable.order(date: :desc).limit(1)
+    non_honorable.order(date: :desc)
   }, class_name: "Discharge", foreign_key: "member_id"
 
   has_many :enlistments, foreign_key: "member_id", inverse_of: :user

--- a/test/controllers/units_controller_test.rb
+++ b/test/controllers/units_controller_test.rb
@@ -58,6 +58,33 @@ class UnitsControllerTest < ActionDispatch::IntegrationTest
     assert_match "Army of Occupation", response.body
   end
 
+  test "missing_awards respects each user's latest non-honorable discharge" do
+    create(:permission, abbr: "awarding_add", unit: @company)
+    awarder = create(:user)
+    create(:assignment, user: awarder, unit: @company)
+    army_of_occupation = create(:award, code: "aocc")
+
+    veteran = create(:user, last_name: "Veteranson")
+    create(:assignment, user: veteran, unit: @squad,
+      start_date: 3.years.ago, end_date: 2.years.ago)
+    create(:discharge, user: veteran, date: 2.years.ago, type: :general)
+    create(:assignment, user: veteran, unit: @squad, start_date: 8.months.ago)
+    create(:user_award, user: veteran, award: army_of_occupation, date: 7.months.ago)
+
+    another_veteran = create(:user)
+    create(:assignment, user: another_veteran, unit: @squad,
+      start_date: 18.months.ago, end_date: 1.year.ago)
+    create(:discharge, user: another_veteran, date: 1.year.ago, type: :general)
+    create(:assignment, user: another_veteran, unit: @squad, start_date: 1.month.ago)
+
+    sign_in_as awarder
+    get unit_missing_awards_url(@company)
+
+    assert_response :success
+    assert_no_match veteran.short_name, response.body
+    assert_match "No missing awards found", response.body
+  end
+
   test "missing_awards refuses members without awarding_add" do
     sign_in_as @member
     get unit_missing_awards_url(@company)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -437,6 +437,26 @@ class UserTest < ActiveSupport::TestCase
     refute user.honorably_discharged?
   end
 
+  test "latest_non_honorable_discharge returns each user's newest non-honorable discharge when preloaded" do
+    user = create(:user)
+    create(:discharge, user:, type: :general, date: 2.years.ago)
+    latest_discharge = create(:discharge, user:, type: :dishonorable, date: 1.year.ago)
+    create(:discharge, user:, type: :honorable, date: 6.months.ago)
+
+    other_user = create(:user)
+    other_latest_discharge = create(:discharge, user: other_user, type: :general, date: 1.month.ago)
+
+    assert_equal latest_discharge, user.latest_non_honorable_discharge
+
+    preloaded_users = User
+      .where(id: [user.id, other_user.id])
+      .includes(:latest_non_honorable_discharge)
+      .index_by(&:id)
+
+    assert_equal latest_discharge, preloaded_users[user.id].latest_non_honorable_discharge
+    assert_equal other_latest_discharge, preloaded_users[other_user.id].latest_non_honorable_discharge
+  end
+
   # service_duration
   test "service_duration sums duration from all assignments" do
     user = create(:user)


### PR DESCRIPTION
This fixes the bug where 'missing awards' unit page was counting users' entire service history, including prior to discharges, for calculating length of service awards due